### PR TITLE
Add DanceClip / Tag / LoopMarker SwiftData models (#2)

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -8,8 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		1EC09265A1CD5B1E67415B39 /* StepBackApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023608F63978F9D1668F5AFC /* StepBackApp.swift */; };
+		1F02ADF6471B01E48A824A49 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6745FF48B10D28A5ED4BB568 /* Models.swift */; };
 		9F90D5641396A9BF3E7A09FE /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E94F050959741028A8574D /* RootView.swift */; };
 		A49A15759EECD46EC5E3A694 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D07843122196F5F0DA539D1 /* Theme.swift */; };
+		C376AB20647940A9E53A89D0 /* ModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848D52E156E709AA0226CEE8 /* ModelsTests.swift */; };
 		C97E59DA25A51E16ECA03607 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C112AEA59633E85CF8267D /* ThemeTests.swift */; };
 		D9873262DD68100D8D3C1021 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 462E264B215595E9EC3D1C4A /* Assets.xcassets */; };
 /* End PBXBuildFile section */
@@ -30,6 +32,8 @@
 		462E264B215595E9EC3D1C4A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		46ED8A21F9D36A90E3306D55 /* StepBackTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = StepBackTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		56E94F050959741028A8574D /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		6745FF48B10D28A5ED4BB568 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
+		848D52E156E709AA0226CEE8 /* ModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsTests.swift; sourceTree = "<group>"; };
 		90115F7F368CDD3B0832B3B3 /* Generated-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Generated-Info.plist"; sourceTree = "<group>"; };
 		A3776C829FB11907CC7E87F9 /* StepBack.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = StepBack.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B7C112AEA59633E85CF8267D /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
@@ -44,6 +48,14 @@
 			path = Utilities;
 			sourceTree = "<group>";
 		};
+		1473B0960203747345667BB7 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				6745FF48B10D28A5ED4BB568 /* Models.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		2BAE89F5B3212B0E382D6904 /* Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -55,6 +67,7 @@
 		AAFDEB01F8F445A32BEBF684 /* StepBackTests */ = {
 			isa = PBXGroup;
 			children = (
+				848D52E156E709AA0226CEE8 /* ModelsTests.swift */,
 				B7C112AEA59633E85CF8267D /* ThemeTests.swift */,
 			);
 			path = StepBackTests;
@@ -63,6 +76,7 @@
 		CD80E836058B8C1643707785 /* StepBack */ = {
 			isa = PBXGroup;
 			children = (
+				1473B0960203747345667BB7 /* Models */,
 				0CCE7D9CB9AEFC2FA82B2EFD /* Utilities */,
 				2BAE89F5B3212B0E382D6904 /* Views */,
 				462E264B215595E9EC3D1C4A /* Assets.xcassets */,
@@ -186,6 +200,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1F02ADF6471B01E48A824A49 /* Models.swift in Sources */,
 				9F90D5641396A9BF3E7A09FE /* RootView.swift in Sources */,
 				1EC09265A1CD5B1E67415B39 /* StepBackApp.swift in Sources */,
 				A49A15759EECD46EC5E3A694 /* Theme.swift in Sources */,
@@ -196,6 +211,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C376AB20647940A9E53A89D0 /* ModelsTests.swift in Sources */,
 				C97E59DA25A51E16ECA03607 /* ThemeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/StepBack/Models/Models.swift
+++ b/StepBack/Models/Models.swift
@@ -1,0 +1,85 @@
+import Foundation
+import SwiftData
+
+@Model
+final class DanceClip {
+    var id: UUID
+    var title: String
+    var assetIdentifier: String
+    var dateAdded: Date
+    var eventName: String?
+    var notes: String
+    var thumbnailData: Data?
+    var durationSeconds: Double
+
+    @Relationship(deleteRule: .cascade, inverse: \LoopMarker.clip)
+    var loopMarkers: [LoopMarker] = []
+
+    var tags: [Tag] = []
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        assetIdentifier: String,
+        dateAdded: Date = Date(),
+        eventName: String? = nil,
+        notes: String = "",
+        thumbnailData: Data? = nil,
+        durationSeconds: Double = 0
+    ) {
+        self.id = id
+        self.title = title
+        self.assetIdentifier = assetIdentifier
+        self.dateAdded = dateAdded
+        self.eventName = eventName
+        self.notes = notes
+        self.thumbnailData = thumbnailData
+        self.durationSeconds = durationSeconds
+    }
+}
+
+@Model
+final class Tag {
+    var id: UUID
+    var name: String
+    var colorHex: String
+
+    @Relationship(inverse: \DanceClip.tags)
+    var clips: [DanceClip] = []
+
+    init(id: UUID = UUID(), name: String, colorHex: String) {
+        self.id = id
+        self.name = name
+        self.colorHex = colorHex
+    }
+}
+
+@Model
+final class LoopMarker {
+    var id: UUID
+    var label: String
+    var startSeconds: Double
+    var endSeconds: Double
+    var preferredSpeed: Double
+    var clip: DanceClip?
+
+    init(
+        id: UUID = UUID(),
+        label: String,
+        startSeconds: Double,
+        endSeconds: Double,
+        preferredSpeed: Double = 1.0,
+        clip: DanceClip? = nil
+    ) {
+        self.id = id
+        self.label = label
+        self.startSeconds = startSeconds
+        self.endSeconds = endSeconds
+        self.preferredSpeed = preferredSpeed
+        self.clip = clip
+    }
+
+    var durationSeconds: Double {
+        max(0, endSeconds - startSeconds)
+    }
+}

--- a/StepBack/StepBackApp.swift
+++ b/StepBack/StepBackApp.swift
@@ -1,3 +1,4 @@
+import SwiftData
 import SwiftUI
 
 @main
@@ -6,5 +7,6 @@ struct StepBackApp: App {
         WindowGroup {
             RootView()
         }
+        .modelContainer(for: [DanceClip.self, Tag.self, LoopMarker.self])
     }
 }

--- a/StepBackTests/ModelsTests.swift
+++ b/StepBackTests/ModelsTests.swift
@@ -1,0 +1,104 @@
+@testable import StepBack
+import SwiftData
+import XCTest
+
+@MainActor
+final class ModelsTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext { container.mainContext }
+
+    override func setUp() async throws {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        container = try ModelContainer(
+            for: DanceClip.self, Tag.self, LoopMarker.self,
+            configurations: config
+        )
+    }
+
+    override func tearDown() async throws {
+        container = nil
+    }
+
+    // MARK: - DanceClip
+
+    func testDanceClipDefaults() throws {
+        let clip = DanceClip(title: "Warmup", assetIdentifier: "ASSET-1")
+        context.insert(clip)
+        try context.save()
+
+        XCTAssertEqual(clip.title, "Warmup")
+        XCTAssertEqual(clip.assetIdentifier, "ASSET-1")
+        XCTAssertEqual(clip.notes, "")
+        XCTAssertNil(clip.eventName)
+        XCTAssertNil(clip.thumbnailData)
+        XCTAssertEqual(clip.durationSeconds, 0)
+        XCTAssertTrue(clip.loopMarkers.isEmpty)
+        XCTAssertTrue(clip.tags.isEmpty)
+    }
+
+    // MARK: - LoopMarker
+
+    func testLoopMarkerRelationshipAndCascadeDelete() throws {
+        let clip = DanceClip(title: "Practice", assetIdentifier: "ASSET-2")
+        let marker = LoopMarker(
+            label: "Hard 8-count",
+            startSeconds: 10,
+            endSeconds: 18,
+            preferredSpeed: 0.5,
+            clip: clip
+        )
+        clip.loopMarkers.append(marker)
+        context.insert(clip)
+        try context.save()
+
+        XCTAssertEqual(clip.loopMarkers.count, 1)
+        XCTAssertIdentical(marker.clip, clip)
+        XCTAssertEqual(marker.durationSeconds, 8, accuracy: 0.0001)
+
+        context.delete(clip)
+        try context.save()
+
+        let remaining = try context.fetch(FetchDescriptor<LoopMarker>())
+        XCTAssertTrue(remaining.isEmpty, "Deleting the clip should cascade to its markers")
+    }
+
+    func testLoopMarkerDurationNeverNegative() {
+        let marker = LoopMarker(label: "Weird", startSeconds: 10, endSeconds: 5)
+        XCTAssertEqual(marker.durationSeconds, 0)
+    }
+
+    // MARK: - Tag
+
+    func testTagManyToManyWithClips() throws {
+        let tag = Tag(name: "Event: Sep 5, 2025", colorHex: "#FF3B7F")
+        let clipA = DanceClip(title: "A", assetIdentifier: "A")
+        let clipB = DanceClip(title: "B", assetIdentifier: "B")
+
+        context.insert(tag)
+        context.insert(clipA)
+        context.insert(clipB)
+        tag.clips.append(contentsOf: [clipA, clipB])
+        try context.save()
+
+        XCTAssertEqual(tag.clips.count, 2)
+        XCTAssertTrue(clipA.tags.contains { $0.id == tag.id })
+        XCTAssertTrue(clipB.tags.contains { $0.id == tag.id })
+    }
+
+    func testDeletingTagDoesNotDeleteClips() throws {
+        let tag = Tag(name: "Lindy basics", colorHex: "#5FE7FF")
+        let clip = DanceClip(title: "Clip", assetIdentifier: "ASSET-3")
+        context.insert(tag)
+        context.insert(clip)
+        tag.clips.append(clip)
+        try context.save()
+
+        context.delete(tag)
+        try context.save()
+
+        let clips = try context.fetch(FetchDescriptor<DanceClip>())
+        XCTAssertEqual(clips.count, 1)
+        XCTAssertTrue(clips[0].tags.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

Adds the three SwiftData \`@Model\` types from the spec, wires a \`ModelContainer\` into \`StepBackApp\`, and covers them with in-memory unit tests.

- \`DanceClip\` owns its \`LoopMarkers\` with cascade delete; inverse declared on the parent side only
- \`Tag\` <-> \`DanceClip\` is a standard many-to-many; deleting a tag detaches but doesn't cascade to clips
- \`LoopMarker.durationSeconds\` clamps to \`>= 0\`
- Beat fields (bpm, beatTimesData, firstDownbeatSeconds, beatsPerMeasure) intentionally deferred to #10 — SwiftData migrates them cleanly as optionals

## Test plan

- [x] \`ModelsTests\` covers:
  - DanceClip default values
  - Cascade delete from clip -> loop markers
  - \`durationSeconds\` non-negativity
  - Tag many-to-many symmetry
  - Tag delete does not delete clips
- [ ] CI build + test green
- [ ] Maintainer: open in Xcode, confirm the app launches with the container wired up (no crash at first launch)

Closes #2