### PR TITLE
LibraryView: grid + multi-select import (#4)

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -9,8 +9,11 @@
 /* Begin PBXBuildFile section */
 		1EC09265A1CD5B1E67415B39 /* StepBackApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023608F63978F9D1668F5AFC /* StepBackApp.swift */; };
 		1F02ADF6471B01E48A824A49 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6745FF48B10D28A5ED4BB568 /* Models.swift */; };
+		527B9B596B00D2C774173ECA /* PracticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35AE6C8D6564306E1B0ADA20 /* PracticeView.swift */; };
+		5F405BD1B2F2EB7F30970683 /* LibraryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */; };
 		9F90D5641396A9BF3E7A09FE /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E94F050959741028A8574D /* RootView.swift */; };
 		A49A15759EECD46EC5E3A694 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D07843122196F5F0DA539D1 /* Theme.swift */; };
+		A88000A1ACD9503F7A9D6143 /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB30650146433E889DC2AF4 /* LibraryView.swift */; };
 		C376AB20647940A9E53A89D0 /* ModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848D52E156E709AA0226CEE8 /* ModelsTests.swift */; };
 		C97E59DA25A51E16ECA03607 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C112AEA59633E85CF8267D /* ThemeTests.swift */; };
 		CC6F98E7716925F88449689A /* PhotosServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */; };
@@ -31,13 +34,16 @@
 /* Begin PBXFileReference section */
 		023608F63978F9D1668F5AFC /* StepBackApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepBackApp.swift; sourceTree = "<group>"; };
 		2D07843122196F5F0DA539D1 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+		35AE6C8D6564306E1B0ADA20 /* PracticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeView.swift; sourceTree = "<group>"; };
 		462E264B215595E9EC3D1C4A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		46ED8A21F9D36A90E3306D55 /* StepBackTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = StepBackTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		56E94F050959741028A8574D /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		6745FF48B10D28A5ED4BB568 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
 		848D52E156E709AA0226CEE8 /* ModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsTests.swift; sourceTree = "<group>"; };
+		8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryFormatterTests.swift; sourceTree = "<group>"; };
 		90115F7F368CDD3B0832B3B3 /* Generated-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Generated-Info.plist"; sourceTree = "<group>"; };
 		A3776C829FB11907CC7E87F9 /* StepBack.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = StepBack.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		AAB30650146433E889DC2AF4 /* LibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryView.swift; sourceTree = "<group>"; };
 		B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosServiceTests.swift; sourceTree = "<group>"; };
 		B7C112AEA59633E85CF8267D /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		D8F8476EAB523378C1F1E046 /* PhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosService.swift; sourceTree = "<group>"; };
@@ -63,6 +69,8 @@
 		2BAE89F5B3212B0E382D6904 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				AAB30650146433E889DC2AF4 /* LibraryView.swift */,
+				35AE6C8D6564306E1B0ADA20 /* PracticeView.swift */,
 				56E94F050959741028A8574D /* RootView.swift */,
 			);
 			path = Views;
@@ -71,6 +79,7 @@
 		AAFDEB01F8F445A32BEBF684 /* StepBackTests */ = {
 			isa = PBXGroup;
 			children = (
+				8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */,
 				848D52E156E709AA0226CEE8 /* ModelsTests.swift */,
 				B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */,
 				B7C112AEA59633E85CF8267D /* ThemeTests.swift */,
@@ -214,8 +223,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A88000A1ACD9503F7A9D6143 /* LibraryView.swift in Sources */,
 				1F02ADF6471B01E48A824A49 /* Models.swift in Sources */,
 				F7AD3FACE8B875F1C9DFA310 /* PhotosService.swift in Sources */,
+				527B9B596B00D2C774173ECA /* PracticeView.swift in Sources */,
 				9F90D5641396A9BF3E7A09FE /* RootView.swift in Sources */,
 				1EC09265A1CD5B1E67415B39 /* StepBackApp.swift in Sources */,
 				A49A15759EECD46EC5E3A694 /* Theme.swift in Sources */,
@@ -226,6 +237,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5F405BD1B2F2EB7F30970683 /* LibraryFormatterTests.swift in Sources */,
 				C376AB20647940A9E53A89D0 /* ModelsTests.swift in Sources */,
 				CC6F98E7716925F88449689A /* PhotosServiceTests.swift in Sources */,
 				C97E59DA25A51E16ECA03607 /* ThemeTests.swift in Sources */,

--- a/StepBack/Views/LibraryView.swift
+++ b/StepBack/Views/LibraryView.swift
@@ -1,0 +1,292 @@
+import AVFoundation
+import Photos
+import PhotosUI
+import SwiftData
+import SwiftUI
+
+struct LibraryView: View {
+
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \DanceClip.dateAdded, order: .reverse) private var clips: [DanceClip]
+
+    @State private var pickerItems: [PhotosPickerItem] = []
+    @State private var importState: ImportState = .idle
+    @State private var importError: String?
+
+    private let columns = [GridItem(.adaptive(minimum: 140), spacing: 12)]
+    private let photosService: PhotosServicing = PhotosService()
+
+    var body: some View {
+        NavigationStack {
+            content
+                .background(Theme.Color.background.ignoresSafeArea())
+                .navigationTitle("Library")
+                .toolbarBackground(Theme.Color.background, for: .navigationBar)
+                .toolbarColorScheme(.dark, for: .navigationBar)
+                .toolbar { toolbar }
+                .alert(
+                    "Import failed",
+                    isPresented: .init(
+                        get: { importError != nil },
+                        set: { if !$0 { importError = nil } }
+                    ),
+                    presenting: importError
+                ) { _ in
+                    Button("OK", role: .cancel) { importError = nil }
+                } message: { message in
+                    Text(message)
+                }
+                .onChange(of: pickerItems) { _, newItems in
+                    guard !newItems.isEmpty else { return }
+                    let items = newItems
+                    pickerItems = []
+                    Task { await importClips(items) }
+                }
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        if clips.isEmpty {
+            emptyState
+        } else {
+            ScrollView {
+                LazyVGrid(columns: columns, spacing: 12) {
+                    ForEach(clips) { clip in
+                        NavigationLink {
+                            PracticeView(clip: clip)
+                        } label: {
+                            LibraryCell(clip: clip)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(12)
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "film.stack")
+                .font(.system(size: 48, weight: .light))
+                .foregroundStyle(Theme.Color.textTertiary)
+            Text("Import videos from Photos to start practicing")
+                .font(Theme.Font.title)
+                .foregroundStyle(Theme.Color.textPrimary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+            importButton
+        }
+        .padding()
+    }
+
+    // MARK: - Toolbar
+
+    @ToolbarContentBuilder
+    private var toolbar: some ToolbarContent {
+        ToolbarItem(placement: .topBarTrailing) {
+            if clips.isEmpty {
+                EmptyView()
+            } else {
+                importButton
+            }
+        }
+        ToolbarItem(placement: .topBarLeading) {
+            if case .importing(let current, let total) = importState {
+                HStack(spacing: 6) {
+                    ProgressView()
+                    Text("\(current)/\(total)")
+                        .font(Theme.Font.caption)
+                        .foregroundStyle(Theme.Color.textSecondary)
+                }
+            }
+        }
+    }
+
+    private var importButton: some View {
+        PhotosPicker(
+            selection: $pickerItems,
+            maxSelectionCount: 50,
+            matching: .videos,
+            preferredItemEncoding: .current
+        ) {
+            Label("Import", systemImage: "plus")
+                .labelStyle(.iconOnly)
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(Theme.Color.accent)
+                .padding(8)
+                .background(Theme.Color.accentSoft, in: Circle())
+        }
+        .disabled(importState.isImporting)
+    }
+
+    // MARK: - Import
+
+    private func importClips(_ items: [PhotosPickerItem]) async {
+        let status = await photosService.requestAuthorization()
+        guard status == .authorized || status == .limited else {
+            importError = "StepBack needs Photos access to import clips. Enable it in Settings."
+            return
+        }
+
+        let total = items.count
+        importState = .importing(current: 0, total: total)
+
+        var imported = 0
+        for (index, item) in items.enumerated() {
+            let current = index + 1
+            importState = .importing(current: current, total: total)
+            do {
+                try await importOne(item)
+                imported += 1
+            } catch {
+                importError = "Couldn't import one of \(total) clips: \(error.localizedDescription)"
+            }
+        }
+
+        importState = .idle
+        if imported == 0, importError == nil {
+            importError = "No clips imported. Make sure you picked videos, not photos."
+        }
+    }
+
+    private func importOne(_ item: PhotosPickerItem) async throws {
+        guard let identifier = item.itemIdentifier else {
+            throw LibraryError.missingAssetIdentifier
+        }
+        if clipExists(withAssetIdentifier: identifier) {
+            return
+        }
+        let urlAsset = try await photosService.resolveAVAsset(for: identifier)
+        let duration = try await urlAsset.load(.duration).seconds
+        let thumbnail = try? await photosService.generateThumbnail(for: urlAsset)
+        let title = defaultTitle(for: urlAsset, identifier: identifier)
+        let creationDate = creationDate(for: identifier) ?? Date()
+
+        let clip = DanceClip(
+            title: title,
+            assetIdentifier: identifier,
+            dateAdded: creationDate,
+            thumbnailData: thumbnail,
+            durationSeconds: duration.isFinite ? duration : 0
+        )
+        modelContext.insert(clip)
+        try modelContext.save()
+    }
+
+    private func clipExists(withAssetIdentifier identifier: String) -> Bool {
+        let descriptor = FetchDescriptor<DanceClip>(
+            predicate: #Predicate { $0.assetIdentifier == identifier }
+        )
+        return (try? modelContext.fetchCount(descriptor)) ?? 0 > 0
+    }
+
+    private func creationDate(for assetIdentifier: String) -> Date? {
+        let result = PHAsset.fetchAssets(withLocalIdentifiers: [assetIdentifier], options: nil)
+        return result.firstObject?.creationDate
+    }
+
+    private func defaultTitle(for asset: AVURLAsset, identifier: String) -> String {
+        let name = asset.url.deletingPathExtension().lastPathComponent
+        if !name.isEmpty, name.lowercased() != "videoclip" {
+            return name
+        }
+        return "Clip \(identifier.prefix(6))"
+    }
+}
+
+// MARK: - Cell
+
+private struct LibraryCell: View {
+    let clip: DanceClip
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            ZStack {
+                Theme.Color.surfaceElevated
+                thumbnail
+                VStack {
+                    Spacer()
+                    HStack {
+                        Spacer()
+                        durationBadge
+                    }
+                }
+                .padding(6)
+            }
+            .frame(height: 180)
+            .clipShape(RoundedRectangle(cornerRadius: Theme.Metrics.cornerRadius))
+
+            Text(clip.title)
+                .font(Theme.Font.bodyEmphasized)
+                .foregroundStyle(Theme.Color.textPrimary)
+                .lineLimit(1)
+
+            Text(clip.dateAdded, style: .date)
+                .font(Theme.Font.caption)
+                .foregroundStyle(Theme.Color.textTertiary)
+        }
+    }
+
+    @ViewBuilder
+    private var thumbnail: some View {
+        if let data = clip.thumbnailData, let uiImage = UIImage(data: data) {
+            Image(uiImage: uiImage)
+                .resizable()
+                .scaledToFill()
+        } else {
+            Image(systemName: "film")
+                .font(.system(size: 28, weight: .light))
+                .foregroundStyle(Theme.Color.textTertiary)
+        }
+    }
+
+    private var durationBadge: some View {
+        Text(LibraryFormatter.duration(clip.durationSeconds))
+            .font(Theme.Font.timestamp)
+            .foregroundStyle(Theme.Color.textPrimary)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Color.black.opacity(0.55), in: Capsule())
+    }
+}
+
+// MARK: - Formatting
+
+enum LibraryFormatter {
+    static func duration(_ seconds: Double) -> String {
+        guard seconds.isFinite, seconds > 0 else { return "--:--" }
+        let whole = Int(seconds.rounded())
+        return String(format: "%d:%02d", whole / 60, whole % 60)
+    }
+}
+
+// MARK: - Supporting types
+
+private enum ImportState: Equatable {
+    case idle
+    case importing(current: Int, total: Int)
+
+    var isImporting: Bool {
+        if case .importing = self { return true }
+        return false
+    }
+}
+
+enum LibraryError: Error, LocalizedError {
+    case missingAssetIdentifier
+
+    var errorDescription: String? {
+        switch self {
+        case .missingAssetIdentifier: "The selected item has no asset identifier."
+        }
+    }
+}
+
+#Preview {
+    LibraryView()
+        .modelContainer(for: [DanceClip.self, Tag.self, LoopMarker.self], inMemory: true)
+}

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct PracticeView: View {
+    let clip: DanceClip
+
+    var body: some View {
+        ZStack {
+            Theme.Color.background.ignoresSafeArea()
+            VStack(spacing: 20) {
+                Image(systemName: "play.rectangle")
+                    .font(.system(size: 56, weight: .light))
+                    .foregroundStyle(Theme.Color.accent)
+                Text(clip.title)
+                    .font(Theme.Font.title)
+                    .foregroundStyle(Theme.Color.textPrimary)
+                Text("Player lands in issue #5.")
+                    .font(Theme.Font.caption)
+                    .foregroundStyle(Theme.Color.textTertiary)
+            }
+            .padding()
+        }
+        .navigationTitle(clip.title)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(Theme.Color.background, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+    }
+}

--- a/StepBack/Views/RootView.swift
+++ b/StepBack/Views/RootView.swift
@@ -2,29 +2,8 @@ import SwiftUI
 
 struct RootView: View {
     var body: some View {
-        ZStack {
-            Theme.Color.background.ignoresSafeArea()
-            VStack(spacing: 24) {
-                Wordmark()
-                Text("Scaffold ready.")
-                    .font(Theme.Font.body)
-                    .foregroundStyle(Theme.Color.textSecondary)
-                Text("Library lands in issue #4.")
-                    .font(Theme.Font.caption)
-                    .foregroundStyle(Theme.Color.textTertiary)
-            }
-        }
-    }
-}
-
-private struct Wordmark: View {
-    var body: some View {
-        HStack(spacing: 0) {
-            Text("STEP").foregroundStyle(Theme.Color.accent)
-            Text("BACK").foregroundStyle(Theme.Color.textPrimary)
-        }
-        .font(.system(size: 38, weight: .black, design: .rounded))
-        .tracking(-1)
+        LibraryView()
+            .preferredColorScheme(.dark)
     }
 }
 

--- a/StepBackTests/LibraryFormatterTests.swift
+++ b/StepBackTests/LibraryFormatterTests.swift
@@ -1,0 +1,27 @@
+@testable import StepBack
+import XCTest
+
+final class LibraryFormatterTests: XCTestCase {
+
+    func testDurationZeroOrNegativeReturnsPlaceholder() {
+        XCTAssertEqual(LibraryFormatter.duration(0), "--:--")
+        XCTAssertEqual(LibraryFormatter.duration(-5), "--:--")
+    }
+
+    func testDurationNonFiniteReturnsPlaceholder() {
+        XCTAssertEqual(LibraryFormatter.duration(.infinity), "--:--")
+        XCTAssertEqual(LibraryFormatter.duration(.nan), "--:--")
+    }
+
+    func testDurationUnderAMinute() {
+        XCTAssertEqual(LibraryFormatter.duration(1), "0:01")
+        XCTAssertEqual(LibraryFormatter.duration(45), "0:45")
+        XCTAssertEqual(LibraryFormatter.duration(59.4), "0:59")
+    }
+
+    func testDurationMultiMinuteRoundsToNearestSecond() {
+        XCTAssertEqual(LibraryFormatter.duration(60), "1:00")
+        XCTAssertEqual(LibraryFormatter.duration(83.6), "1:24")
+        XCTAssertEqual(LibraryFormatter.duration(3 * 60 + 7.5), "3:08")
+    }
+}


### PR DESCRIPTION
## Summary

Entry point of the app — a SwiftData-backed grid of imported clips, multi-select import from Photos, and a navigation hop into the (stubbed) PracticeView.

- \`@Query\` sorts clips by \`dateAdded\` descending
- Empty state: \`film.stack\` icon + import CTA
- \`PhotosPicker\` with \`maxSelectionCount: 50\`, \`matching: .videos\`
- Import flow: authorize → resolve AVURLAsset → 400×400 JPEG thumbnail → save \`DanceClip\` with the PHAsset \`creationDate\` so #8 can cluster by event later
- Duplicate detection by \`assetIdentifier\` (re-picking is a no-op)
- Per-item progress badge (\`3/12\`) in the toolbar
- Clean \`LibraryFormatter\` for duration strings, covered by unit tests
- Stubbed \`PracticeView\` so the navigation link compiles until #5

## Test plan

- [x] \`LibraryFormatterTests\` covers zero/negative, non-finite, sub-minute, and multi-minute durations
- [ ] CI green
- [ ] Maintainer, on device:
  - [ ] First launch shows empty state
  - [ ] Tapping import surfaces Photos consent, then the picker
  - [ ] Pick a handful of videos → they land in the grid with thumbnails, ordered newest first
  - [ ] Re-picking the same clip does not duplicate the row
  - [ ] Duration badge matches the clip length
  - [ ] Tapping a cell pushes the stub PracticeView

## Notes for reviewer

Runtime error paths (permission denied, failed thumbnail, unreadable asset) surface as alerts but aren't covered by CI tests — the simulator's Photos framework is flaky. Verify on device.

Closes #4