### PR TITLE
PracticeView skeleton: player, scrubber, speed pills (#5)

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1F02ADF6471B01E48A824A49 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6745FF48B10D28A5ED4BB568 /* Models.swift */; };
 		527B9B596B00D2C774173ECA /* PracticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35AE6C8D6564306E1B0ADA20 /* PracticeView.swift */; };
 		5F405BD1B2F2EB7F30970683 /* LibraryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */; };
+		7FA3BBA0113FDF3282819E84 /* PracticePlayerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */; };
 		9F90D5641396A9BF3E7A09FE /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E94F050959741028A8574D /* RootView.swift */; };
 		A49A15759EECD46EC5E3A694 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D07843122196F5F0DA539D1 /* Theme.swift */; };
 		A88000A1ACD9503F7A9D6143 /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB30650146433E889DC2AF4 /* LibraryView.swift */; };
@@ -18,6 +19,7 @@
 		C97E59DA25A51E16ECA03607 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C112AEA59633E85CF8267D /* ThemeTests.swift */; };
 		CC6F98E7716925F88449689A /* PhotosServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */; };
 		D9873262DD68100D8D3C1021 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 462E264B215595E9EC3D1C4A /* Assets.xcassets */; };
+		F35848C14CA3DF06A4EBE554 /* SpeedFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E676751B59ED083837CE39 /* SpeedFormatterTests.swift */; };
 		F7AD3FACE8B875F1C9DFA310 /* PhotosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F8476EAB523378C1F1E046 /* PhotosService.swift */; };
 /* End PBXBuildFile section */
 
@@ -33,10 +35,12 @@
 
 /* Begin PBXFileReference section */
 		023608F63978F9D1668F5AFC /* StepBackApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepBackApp.swift; sourceTree = "<group>"; };
+		16E676751B59ED083837CE39 /* SpeedFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedFormatterTests.swift; sourceTree = "<group>"; };
 		2D07843122196F5F0DA539D1 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		35AE6C8D6564306E1B0ADA20 /* PracticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeView.swift; sourceTree = "<group>"; };
 		462E264B215595E9EC3D1C4A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		46ED8A21F9D36A90E3306D55 /* StepBackTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = StepBackTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticePlayerViewModel.swift; sourceTree = "<group>"; };
 		56E94F050959741028A8574D /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		6745FF48B10D28A5ED4BB568 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
 		848D52E156E709AA0226CEE8 /* ModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsTests.swift; sourceTree = "<group>"; };
@@ -82,6 +86,7 @@
 				8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */,
 				848D52E156E709AA0226CEE8 /* ModelsTests.swift */,
 				B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */,
+				16E676751B59ED083837CE39 /* SpeedFormatterTests.swift */,
 				B7C112AEA59633E85CF8267D /* ThemeTests.swift */,
 			);
 			path = StepBackTests;
@@ -91,6 +96,7 @@
 			isa = PBXGroup;
 			children = (
 				D8F8476EAB523378C1F1E046 /* PhotosService.swift */,
+				543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -226,6 +232,7 @@
 				A88000A1ACD9503F7A9D6143 /* LibraryView.swift in Sources */,
 				1F02ADF6471B01E48A824A49 /* Models.swift in Sources */,
 				F7AD3FACE8B875F1C9DFA310 /* PhotosService.swift in Sources */,
+				7FA3BBA0113FDF3282819E84 /* PracticePlayerViewModel.swift in Sources */,
 				527B9B596B00D2C774173ECA /* PracticeView.swift in Sources */,
 				9F90D5641396A9BF3E7A09FE /* RootView.swift in Sources */,
 				1EC09265A1CD5B1E67415B39 /* StepBackApp.swift in Sources */,
@@ -240,6 +247,7 @@
 				5F405BD1B2F2EB7F30970683 /* LibraryFormatterTests.swift in Sources */,
 				C376AB20647940A9E53A89D0 /* ModelsTests.swift in Sources */,
 				CC6F98E7716925F88449689A /* PhotosServiceTests.swift in Sources */,
+				F35848C14CA3DF06A4EBE554 /* SpeedFormatterTests.swift in Sources */,
 				C97E59DA25A51E16ECA03607 /* ThemeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/StepBack/Services/PracticePlayerViewModel.swift
+++ b/StepBack/Services/PracticePlayerViewModel.swift
@@ -1,0 +1,99 @@
+import AVFoundation
+import Combine
+import Foundation
+
+@MainActor
+final class PracticePlayerViewModel: ObservableObject {
+
+    @Published private(set) var isPlaying: Bool = false
+    @Published private(set) var currentTime: Double = 0
+    @Published private(set) var duration: Double = 0
+    @Published private(set) var speed: Double = 1.0
+    @Published private(set) var isReady: Bool = false
+    @Published var loadError: String?
+
+    let player: AVPlayer
+    private var timeObserver: Any?
+    private var playerItem: AVPlayerItem?
+
+    private let assetIdentifier: String
+    private let photosService: PhotosServicing
+
+    init(
+        assetIdentifier: String,
+        photosService: PhotosServicing = PhotosService(),
+        player: AVPlayer = AVPlayer()
+    ) {
+        self.assetIdentifier = assetIdentifier
+        self.photosService = photosService
+        self.player = player
+        attachTimeObserver()
+    }
+
+    deinit {
+        if let timeObserver {
+            player.removeTimeObserver(timeObserver)
+        }
+    }
+
+    // MARK: - Loading
+
+    func load() async {
+        guard !isReady else { return }
+        do {
+            let urlAsset = try await photosService.resolveAVAsset(for: assetIdentifier)
+            let loadedDuration = try await urlAsset.load(.duration).seconds
+            let item = AVPlayerItem(asset: urlAsset)
+            item.audioTimePitchAlgorithm = .timeDomain
+            player.replaceCurrentItem(with: item)
+            playerItem = item
+            duration = loadedDuration.isFinite ? loadedDuration : 0
+            isReady = true
+        } catch {
+            loadError = error.localizedDescription
+        }
+    }
+
+    // MARK: - Transport
+
+    func togglePlayPause() {
+        if isPlaying {
+            player.pause()
+            isPlaying = false
+        } else {
+            player.playImmediately(atRate: Float(speed))
+            isPlaying = true
+        }
+    }
+
+    func seek(to seconds: Double) {
+        let clamped = max(0, min(seconds, duration))
+        let time = CMTime(seconds: clamped, preferredTimescale: 600)
+        player.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero)
+        currentTime = clamped
+    }
+
+    func setSpeed(_ newSpeed: Double) {
+        speed = newSpeed
+        if isPlaying {
+            player.rate = Float(newSpeed)
+        }
+    }
+
+    // MARK: - Observers
+
+    private func attachTimeObserver() {
+        let interval = CMTime(seconds: 0.1, preferredTimescale: 600)
+        timeObserver = player.addPeriodicTimeObserver(
+            forInterval: interval,
+            queue: .main
+        ) { [weak self] time in
+            guard let self else { return }
+            let seconds = time.seconds
+            if seconds.isFinite {
+                self.currentTime = seconds
+            }
+            self.isPlaying = self.player.rate > 0
+        }
+    }
+}

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -1,27 +1,230 @@
+import AVFoundation
+import AVKit
 import SwiftUI
+import UIKit
 
 struct PracticeView: View {
+
     let clip: DanceClip
+
+    @StateObject private var vm: PracticePlayerViewModel
+
+    init(clip: DanceClip) {
+        self.clip = clip
+        _vm = StateObject(
+            wrappedValue: PracticePlayerViewModel(assetIdentifier: clip.assetIdentifier)
+        )
+    }
 
     var body: some View {
         ZStack {
             Theme.Color.background.ignoresSafeArea()
-            VStack(spacing: 20) {
-                Image(systemName: "play.rectangle")
-                    .font(.system(size: 56, weight: .light))
-                    .foregroundStyle(Theme.Color.accent)
-                Text(clip.title)
-                    .font(Theme.Font.title)
-                    .foregroundStyle(Theme.Color.textPrimary)
-                Text("Player lands in issue #5.")
-                    .font(Theme.Font.caption)
-                    .foregroundStyle(Theme.Color.textTertiary)
-            }
-            .padding()
+            content
         }
         .navigationTitle(clip.title)
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(Theme.Color.background, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
+        .task { await vm.load() }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let error = vm.loadError {
+            loadErrorState(message: error)
+        } else if !vm.isReady {
+            ProgressView()
+                .tint(Theme.Color.accent)
+        } else {
+            VStack(spacing: 0) {
+                PlayerSurface(player: vm.player)
+                    .aspectRatio(16.0 / 9.0, contentMode: .fit)
+                    .background(Color.black)
+                controls
+            }
+        }
+    }
+
+    private func loadErrorState(message: String) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 40, weight: .light))
+                .foregroundStyle(Theme.Color.accent)
+            Text("Couldn't load this clip")
+                .font(Theme.Font.title)
+                .foregroundStyle(Theme.Color.textPrimary)
+            Text(message)
+                .font(Theme.Font.caption)
+                .foregroundStyle(Theme.Color.textSecondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+    }
+
+    // MARK: - Controls
+
+    private var controls: some View {
+        VStack(spacing: 14) {
+            Scrubber(
+                currentTime: vm.currentTime,
+                duration: vm.duration,
+                onSeek: vm.seek(to:)
+            )
+            HStack {
+                Text(SpeedFormatter.timestamp(vm.currentTime))
+                    .font(Theme.Font.timestamp)
+                    .foregroundStyle(Theme.Color.textSecondary)
+                Spacer()
+                Text(SpeedFormatter.timestamp(vm.duration))
+                    .font(Theme.Font.timestamp)
+                    .foregroundStyle(Theme.Color.textSecondary)
+            }
+            HStack {
+                Spacer()
+                Button {
+                    vm.togglePlayPause()
+                } label: {
+                    Image(systemName: vm.isPlaying ? "pause.fill" : "play.fill")
+                        .font(.system(size: 26, weight: .semibold))
+                        .foregroundStyle(.black)
+                        .frame(width: 64, height: 64)
+                        .background(Theme.Color.accent, in: Circle())
+                }
+                .buttonStyle(.plain)
+                Spacer()
+            }
+            SpeedPills(selected: vm.speed, onSelect: vm.setSpeed(_:))
+        }
+        .padding(16)
+    }
+}
+
+// MARK: - Player surface
+
+private struct PlayerSurface: UIViewRepresentable {
+    let player: AVPlayer
+
+    func makeUIView(context: Context) -> PlayerView {
+        let view = PlayerView()
+        view.playerLayer.player = player
+        view.playerLayer.videoGravity = .resizeAspect
+        return view
+    }
+
+    func updateUIView(_ uiView: PlayerView, context: Context) {
+        uiView.playerLayer.player = player
+    }
+}
+
+private final class PlayerView: UIView {
+    override static var layerClass: AnyClass { AVPlayerLayer.self }
+
+    var playerLayer: AVPlayerLayer {
+        guard let layer = layer as? AVPlayerLayer else {
+            preconditionFailure("PlayerView.layer must be an AVPlayerLayer")
+        }
+        return layer
+    }
+}
+
+// MARK: - Scrubber
+
+private struct Scrubber: View {
+    let currentTime: Double
+    let duration: Double
+    let onSeek: (Double) -> Void
+
+    @GestureState private var dragProgress: Double?
+
+    var body: some View {
+        GeometryReader { geo in
+            let width = max(1, geo.size.width)
+            let progress = dragProgress ?? (duration > 0 ? min(1, currentTime / duration) : 0)
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(Theme.Color.surfaceElevated)
+                    .frame(height: 6)
+                Capsule()
+                    .fill(Theme.Color.accent)
+                    .frame(width: width * progress, height: 6)
+                Circle()
+                    .fill(Theme.Color.accent)
+                    .frame(width: 16, height: 16)
+                    .offset(x: max(0, width * progress - 8))
+            }
+            .frame(maxHeight: .infinity)
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .updating($dragProgress) { value, state, _ in
+                        state = min(1, max(0, value.location.x / width))
+                    }
+                    .onEnded { value in
+                        let ratio = min(1, max(0, value.location.x / width))
+                        if duration > 0 {
+                            onSeek(ratio * duration)
+                        }
+                    }
+            )
+        }
+        .frame(height: 32)
+    }
+}
+
+// MARK: - Speed pills
+
+private struct SpeedPills: View {
+    static let speeds: [Double] = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5]
+    let selected: Double
+    let onSelect: (Double) -> Void
+
+    var body: some View {
+        HStack(spacing: 6) {
+            ForEach(Self.speeds, id: \.self) { speed in
+                let isSelected = SpeedFormatter.equals(selected, speed)
+                let tint = Theme.Color.speedPillColor(for: speed)
+                Button {
+                    onSelect(speed)
+                } label: {
+                    Text(SpeedFormatter.pill(speed))
+                        .font(.system(.footnote, design: .rounded, weight: .semibold))
+                        .foregroundStyle(isSelected ? .black : tint)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(
+                            Capsule()
+                                .fill(isSelected ? tint : Theme.Color.surfaceElevated)
+                        )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}
+
+// MARK: - Formatting
+
+enum SpeedFormatter {
+    static func pill(_ speed: Double) -> String {
+        let base: String
+        if speed == speed.rounded() {
+            base = "\(Int(speed))"
+        } else {
+            base = String(format: "%g", speed)
+        }
+        return "\(base)×"
+    }
+
+    static func timestamp(_ seconds: Double) -> String {
+        guard seconds.isFinite, seconds >= 0 else { return "--:--" }
+        let totalCentis = Int((seconds * 100).rounded())
+        let mins = totalCentis / 6000
+        let secs = (totalCentis / 100) % 60
+        let cent = totalCentis % 100
+        return String(format: "%d:%02d.%02d", mins, secs, cent)
+    }
+
+    static func equals(_ a: Double, _ b: Double) -> Bool {
+        abs(a - b) < 0.001
     }
 }

--- a/StepBackTests/SpeedFormatterTests.swift
+++ b/StepBackTests/SpeedFormatterTests.swift
@@ -1,0 +1,38 @@
+@testable import StepBack
+import XCTest
+
+final class SpeedFormatterTests: XCTestCase {
+
+    func testPillFormatting() {
+        XCTAssertEqual(SpeedFormatter.pill(0.25), "0.25×")
+        XCTAssertEqual(SpeedFormatter.pill(0.5), "0.5×")
+        XCTAssertEqual(SpeedFormatter.pill(0.75), "0.75×")
+        XCTAssertEqual(SpeedFormatter.pill(1), "1×")
+        XCTAssertEqual(SpeedFormatter.pill(1.25), "1.25×")
+        XCTAssertEqual(SpeedFormatter.pill(1.5), "1.5×")
+    }
+
+    func testEqualsTolerance() {
+        XCTAssertTrue(SpeedFormatter.equals(1.0, 1.0))
+        XCTAssertTrue(SpeedFormatter.equals(0.5, 0.5 + 1e-9))
+        XCTAssertFalse(SpeedFormatter.equals(0.5, 0.75))
+    }
+
+    func testTimestampZero() {
+        XCTAssertEqual(SpeedFormatter.timestamp(0), "0:00.00")
+    }
+
+    func testTimestampUnderAMinute() {
+        XCTAssertEqual(SpeedFormatter.timestamp(12.34), "0:12.34")
+    }
+
+    func testTimestampOverAMinute() {
+        XCTAssertEqual(SpeedFormatter.timestamp(83.56), "1:23.56")
+    }
+
+    func testTimestampNonFiniteOrNegative() {
+        XCTAssertEqual(SpeedFormatter.timestamp(.infinity), "--:--")
+        XCTAssertEqual(SpeedFormatter.timestamp(.nan), "--:--")
+        XCTAssertEqual(SpeedFormatter.timestamp(-1), "--:--")
+    }
+}


### PR DESCRIPTION
## Summary

First playable version of the practice screen. Sets up the transport primitives loops and frame-stepping will sit on top of (#6, #7).

- \`PracticePlayerViewModel\` (@MainActor):
  - Owns an \`AVPlayer\`
  - Resolves the clip via PhotosService and installs an \`AVPlayerItem\` with \`audioTimePitchAlgorithm = .timeDomain\` — pitch-preserved slow-mo
  - \`togglePlayPause\` / \`seek(to:)\` / \`setSpeed(_:)\`
  - \`seek\` uses \`toleranceBefore: .zero, toleranceAfter: .zero\` (prep for tight loops in #6)
  - Periodic time observer at 0.1s drives \`currentTime\`; \`[weak self]\` + \`deinit\` teardown
- \`PracticeView\`:
  - Loading / error / ready states
  - \`PlayerSurface\` UIViewRepresentable hosting \`AVPlayerLayer\` (not \`VideoPlayer\` — needed for compare view reuse)
  - Scrubber with \`DragGesture(minimumDistance: 0)\` so single taps seek
  - Play/pause button + 6 speed pills colored by \`Theme.Color.speedPillColor\`
- \`SpeedFormatter\` covers pill text, a float-equality helper, and a frame-granular timestamp; tests include floating-point edge cases that naive \`Int((seconds - whole) * 100)\` truncation would mishandle

## Test plan

- [x] \`SpeedFormatterTests\` — pill labels, timestamp formatting, tolerance
- [ ] CI green
- [ ] Maintainer, on device:
  - [ ] Clip loads and plays
  - [ ] All 6 speed pills change speed without pitch-shifting the audio
  - [ ] Scrubber responds to taps and drags; end-of-drag seeks
  - [ ] Play button mirrors \`isPlaying\`
  - [ ] Navigating away stops playback cleanly

## Notes for reviewer

- A/B loop, named markers, frame stepping, and mirror mode are deferred to #6 and #7 per the spec's build order.
- Mirroring \`isPlaying\` from the rate observer is intentionally eager — setting \`rate\` to 0 via pause should flip the icon within 100ms.

Closes #5