### PR TITLE
A/B loop + named markers (#6)

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		9F90D5641396A9BF3E7A09FE /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E94F050959741028A8574D /* RootView.swift */; };
 		A49A15759EECD46EC5E3A694 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D07843122196F5F0DA539D1 /* Theme.swift */; };
 		A88000A1ACD9503F7A9D6143 /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB30650146433E889DC2AF4 /* LibraryView.swift */; };
+		BE33E08127A1601493FB7837 /* LoopEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57317F752B65258CB2D04530 /* LoopEvaluatorTests.swift */; };
 		C376AB20647940A9E53A89D0 /* ModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848D52E156E709AA0226CEE8 /* ModelsTests.swift */; };
 		C97E59DA25A51E16ECA03607 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C112AEA59633E85CF8267D /* ThemeTests.swift */; };
 		CC6F98E7716925F88449689A /* PhotosServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */; };
@@ -42,6 +43,7 @@
 		46ED8A21F9D36A90E3306D55 /* StepBackTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = StepBackTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticePlayerViewModel.swift; sourceTree = "<group>"; };
 		56E94F050959741028A8574D /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		57317F752B65258CB2D04530 /* LoopEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopEvaluatorTests.swift; sourceTree = "<group>"; };
 		6745FF48B10D28A5ED4BB568 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
 		848D52E156E709AA0226CEE8 /* ModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsTests.swift; sourceTree = "<group>"; };
 		8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryFormatterTests.swift; sourceTree = "<group>"; };
@@ -84,6 +86,7 @@
 			isa = PBXGroup;
 			children = (
 				8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */,
+				57317F752B65258CB2D04530 /* LoopEvaluatorTests.swift */,
 				848D52E156E709AA0226CEE8 /* ModelsTests.swift */,
 				B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */,
 				16E676751B59ED083837CE39 /* SpeedFormatterTests.swift */,
@@ -245,6 +248,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5F405BD1B2F2EB7F30970683 /* LibraryFormatterTests.swift in Sources */,
+				BE33E08127A1601493FB7837 /* LoopEvaluatorTests.swift in Sources */,
 				C376AB20647940A9E53A89D0 /* ModelsTests.swift in Sources */,
 				CC6F98E7716925F88449689A /* PhotosServiceTests.swift in Sources */,
 				F35848C14CA3DF06A4EBE554 /* SpeedFormatterTests.swift in Sources */,

--- a/StepBack/Services/PracticePlayerViewModel.swift
+++ b/StepBack/Services/PracticePlayerViewModel.swift
@@ -12,6 +12,9 @@ final class PracticePlayerViewModel: ObservableObject {
     @Published private(set) var isReady: Bool = false
     @Published var loadError: String?
 
+    @Published private(set) var loopStart: Double?
+    @Published private(set) var loopEnd: Double?
+
     let player: AVPlayer
     private var timeObserver: Any?
     private var playerItem: AVPlayerItem?
@@ -80,6 +83,40 @@ final class PracticePlayerViewModel: ObservableObject {
         }
     }
 
+    // MARK: - A/B loop
+
+    var hasLoopRegion: Bool {
+        guard let start = loopStart, let end = loopEnd else { return false }
+        return end > start
+    }
+
+    func markLoopStart() {
+        loopStart = currentTime
+        if let end = loopEnd, end <= currentTime {
+            loopEnd = nil
+        }
+    }
+
+    func markLoopEnd() {
+        if let start = loopStart, currentTime <= start {
+            // Ignore: an end-before-start marker would be invalid.
+            return
+        }
+        loopEnd = currentTime
+    }
+
+    func clearLoop() {
+        loopStart = nil
+        loopEnd = nil
+    }
+
+    func applyMarker(_ marker: LoopMarker) {
+        loopStart = marker.startSeconds
+        loopEnd = marker.endSeconds
+        setSpeed(marker.preferredSpeed)
+        seek(to: marker.startSeconds)
+    }
+
     // MARK: - Observers
 
     private func attachTimeObserver() {
@@ -92,8 +129,38 @@ final class PracticePlayerViewModel: ObservableObject {
             let seconds = time.seconds
             if seconds.isFinite {
                 self.currentTime = seconds
+                if case .seek(let target) = LoopEvaluator.action(
+                    currentTime: seconds,
+                    loopStart: self.loopStart,
+                    loopEnd: self.loopEnd
+                ) {
+                    self.seek(to: target)
+                }
             }
             self.isPlaying = self.player.rate > 0
         }
+    }
+}
+
+// MARK: - Pure loop logic (testable without AVPlayer)
+
+enum LoopEvaluator {
+    enum Action: Equatable {
+        case none
+        case seek(to: Double)
+    }
+
+    static func action(
+        currentTime: Double,
+        loopStart: Double?,
+        loopEnd: Double?
+    ) -> Action {
+        guard let start = loopStart, let end = loopEnd, end > start else {
+            return .none
+        }
+        if currentTime >= end {
+            return .seek(to: start)
+        }
+        return .none
     }
 }

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import AVKit
+import SwiftData
 import SwiftUI
 import UIKit
 
@@ -7,7 +8,9 @@ struct PracticeView: View {
 
     let clip: DanceClip
 
+    @Environment(\.modelContext) private var modelContext
     @StateObject private var vm: PracticePlayerViewModel
+    @State private var markerSheetPresented = false
 
     init(clip: DanceClip) {
         self.clip = clip
@@ -26,6 +29,33 @@ struct PracticeView: View {
         .toolbarBackground(Theme.Color.background, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
         .task { await vm.load() }
+        .sheet(isPresented: $markerSheetPresented) {
+            SaveMarkerSheet(
+                defaultSpeed: vm.speed,
+                defaultRegion: (vm.loopStart ?? 0, vm.loopEnd ?? 0)
+            ) { label, speed in
+                saveMarker(label: label, speed: speed)
+            }
+            .presentationDetents([.medium])
+        }
+    }
+
+    private func saveMarker(label: String, speed: Double) {
+        guard let start = vm.loopStart, let end = vm.loopEnd, end > start else { return }
+        let marker = LoopMarker(
+            label: label,
+            startSeconds: start,
+            endSeconds: end,
+            preferredSpeed: speed,
+            clip: clip
+        )
+        modelContext.insert(marker)
+        try? modelContext.save()
+    }
+
+    private func deleteMarker(_ marker: LoopMarker) {
+        modelContext.delete(marker)
+        try? modelContext.save()
     }
 
     @ViewBuilder
@@ -68,6 +98,8 @@ struct PracticeView: View {
             Scrubber(
                 currentTime: vm.currentTime,
                 duration: vm.duration,
+                loopStart: vm.loopStart,
+                loopEnd: vm.loopEnd,
                 onSeek: vm.seek(to:)
             )
             HStack {
@@ -79,6 +111,7 @@ struct PracticeView: View {
                     .font(Theme.Font.timestamp)
                     .foregroundStyle(Theme.Color.textSecondary)
             }
+            loopControls
             HStack {
                 Spacer()
                 Button {
@@ -94,8 +127,57 @@ struct PracticeView: View {
                 Spacer()
             }
             SpeedPills(selected: vm.speed, onSelect: vm.setSpeed(_:))
+            MarkerList(
+                markers: clip.loopMarkers.sorted { $0.startSeconds < $1.startSeconds },
+                onApply: vm.applyMarker,
+                onDelete: deleteMarker
+            )
         }
         .padding(16)
+    }
+
+    private var loopControls: some View {
+        HStack(spacing: 10) {
+            LoopButton(
+                label: "A",
+                filled: vm.loopStart != nil,
+                caption: vm.loopStart.map(SpeedFormatter.timestamp)
+            ) {
+                vm.markLoopStart()
+            }
+            LoopButton(
+                label: "B",
+                filled: vm.loopEnd != nil,
+                caption: vm.loopEnd.map(SpeedFormatter.timestamp)
+            ) {
+                vm.markLoopEnd()
+            }
+            Spacer()
+            if vm.hasLoopRegion {
+                Button {
+                    markerSheetPresented = true
+                } label: {
+                    Label("Save", systemImage: "bookmark.fill")
+                        .font(.system(.footnote, design: .rounded, weight: .semibold))
+                        .foregroundStyle(Theme.Color.accent)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(Theme.Color.accentSoft, in: Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+            if vm.loopStart != nil || vm.loopEnd != nil {
+                Button {
+                    vm.clearLoop()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 22))
+                        .foregroundStyle(Theme.Color.textTertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear loop")
+            }
+        }
     }
 }
 
@@ -132,6 +214,8 @@ private final class PlayerView: UIView {
 private struct Scrubber: View {
     let currentTime: Double
     let duration: Double
+    let loopStart: Double?
+    let loopEnd: Double?
     let onSeek: (Double) -> Void
 
     @GestureState private var dragProgress: Double?
@@ -144,6 +228,7 @@ private struct Scrubber: View {
                 Capsule()
                     .fill(Theme.Color.surfaceElevated)
                     .frame(height: 6)
+                loopRegionOverlay(width: width)
                 Capsule()
                     .fill(Theme.Color.accent)
                     .frame(width: width * progress, height: 6)
@@ -168,6 +253,24 @@ private struct Scrubber: View {
             )
         }
         .frame(height: 32)
+    }
+
+    @ViewBuilder
+    private func loopRegionOverlay(width: CGFloat) -> some View {
+        if duration > 0, let start = loopStart, let end = loopEnd, end > start {
+            let startX = width * min(1, max(0, start / duration))
+            let endX = width * min(1, max(0, end / duration))
+            Capsule()
+                .fill(Theme.Color.accentSoft)
+                .frame(width: max(2, endX - startX), height: 10)
+                .offset(x: startX)
+            ForEach([startX, endX], id: \.self) { edge in
+                Rectangle()
+                    .fill(Theme.Color.accent)
+                    .frame(width: 2, height: 14)
+                    .offset(x: max(0, edge - 1))
+            }
+        }
     }
 }
 
@@ -199,6 +302,158 @@ private struct SpeedPills: View {
                 .buttonStyle(.plain)
             }
         }
+    }
+}
+
+// MARK: - Loop controls
+
+private struct LoopButton: View {
+    let label: String
+    let filled: Bool
+    let caption: String?
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                Text(label)
+                    .font(.system(.body, design: .rounded, weight: .bold))
+                    .foregroundStyle(filled ? .black : Theme.Color.textPrimary)
+                    .frame(width: 28, height: 28)
+                    .background(
+                        Circle().fill(filled ? Theme.Color.accent : Theme.Color.surfaceElevated)
+                    )
+                if let caption {
+                    Text(caption)
+                        .font(Theme.Font.timestamp)
+                        .foregroundStyle(Theme.Color.textSecondary)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Markers
+
+private struct MarkerList: View {
+    let markers: [LoopMarker]
+    let onApply: (LoopMarker) -> Void
+    let onDelete: (LoopMarker) -> Void
+
+    var body: some View {
+        if markers.isEmpty {
+            EmptyView()
+        } else {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(markers) { marker in
+                        MarkerChip(marker: marker, onApply: onApply, onDelete: onDelete)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+}
+
+private struct MarkerChip: View {
+    let marker: LoopMarker
+    let onApply: (LoopMarker) -> Void
+    let onDelete: (LoopMarker) -> Void
+
+    var body: some View {
+        Button {
+            onApply(marker)
+        } label: {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(marker.label)
+                    .font(.system(.footnote, design: .rounded, weight: .semibold))
+                    .foregroundStyle(Theme.Color.textPrimary)
+                    .lineLimit(1)
+                HStack(spacing: 4) {
+                    Text(SpeedFormatter.timestamp(marker.startSeconds))
+                    Text("–")
+                    Text(SpeedFormatter.timestamp(marker.endSeconds))
+                    Text("·")
+                    Text(SpeedFormatter.pill(marker.preferredSpeed))
+                }
+                .font(Theme.Font.timestamp)
+                .foregroundStyle(Theme.Color.textTertiary)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(Theme.Color.surfaceElevated, in: RoundedRectangle(cornerRadius: 10))
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            Button(role: .destructive) {
+                onDelete(marker)
+            } label: {
+                Label("Delete marker", systemImage: "trash")
+            }
+        }
+    }
+}
+
+// MARK: - Save marker sheet
+
+private struct SaveMarkerSheet: View {
+    let defaultSpeed: Double
+    let defaultRegion: (start: Double, end: Double)
+    let onSave: (String, Double) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var label: String = ""
+    @State private var speed: Double
+
+    init(
+        defaultSpeed: Double,
+        defaultRegion: (start: Double, end: Double),
+        onSave: @escaping (String, Double) -> Void
+    ) {
+        self.defaultSpeed = defaultSpeed
+        self.defaultRegion = defaultRegion
+        self.onSave = onSave
+        _speed = State(initialValue: defaultSpeed)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Name") {
+                    TextField("Hard 8-count", text: $label)
+                }
+                Section("Region") {
+                    LabeledContent("Start", value: SpeedFormatter.timestamp(defaultRegion.start))
+                        .foregroundStyle(Theme.Color.textSecondary)
+                    LabeledContent("End", value: SpeedFormatter.timestamp(defaultRegion.end))
+                        .foregroundStyle(Theme.Color.textSecondary)
+                }
+                Section("Preferred speed") {
+                    SpeedPills(selected: speed, onSelect: { speed = $0 })
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .listRowBackground(Color.clear)
+                }
+            }
+            .scrollContentBackground(.hidden)
+            .background(Theme.Color.background)
+            .navigationTitle("Save loop")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
+                        onSave(trimmed.isEmpty ? "Marker" : trimmed, speed)
+                        dismiss()
+                    }
+                }
+            }
+        }
+        .preferredColorScheme(.dark)
     }
 }
 

--- a/StepBackTests/LoopEvaluatorTests.swift
+++ b/StepBackTests/LoopEvaluatorTests.swift
@@ -1,0 +1,62 @@
+@testable import StepBack
+import XCTest
+
+final class LoopEvaluatorTests: XCTestCase {
+
+    func testNoLoopReturnsNone() {
+        XCTAssertEqual(
+            LoopEvaluator.action(currentTime: 5, loopStart: nil, loopEnd: nil),
+            .none
+        )
+    }
+
+    func testHalfLoopReturnsNone() {
+        XCTAssertEqual(
+            LoopEvaluator.action(currentTime: 5, loopStart: 3, loopEnd: nil),
+            .none
+        )
+        XCTAssertEqual(
+            LoopEvaluator.action(currentTime: 5, loopStart: nil, loopEnd: 8),
+            .none
+        )
+    }
+
+    func testDegenerateRangeReturnsNone() {
+        XCTAssertEqual(
+            LoopEvaluator.action(currentTime: 5, loopStart: 8, loopEnd: 8),
+            .none
+        )
+        XCTAssertEqual(
+            LoopEvaluator.action(currentTime: 5, loopStart: 10, loopEnd: 8),
+            .none
+        )
+    }
+
+    func testInsideLoopReturnsNone() {
+        XCTAssertEqual(
+            LoopEvaluator.action(currentTime: 5, loopStart: 3, loopEnd: 8),
+            .none
+        )
+    }
+
+    func testAtLoopEndSeeksToStart() {
+        XCTAssertEqual(
+            LoopEvaluator.action(currentTime: 8, loopStart: 3, loopEnd: 8),
+            .seek(to: 3)
+        )
+    }
+
+    func testPastLoopEndSeeksToStart() {
+        XCTAssertEqual(
+            LoopEvaluator.action(currentTime: 8.4, loopStart: 3, loopEnd: 8),
+            .seek(to: 3)
+        )
+    }
+
+    func testBeforeLoopStartReturnsNone() {
+        XCTAssertEqual(
+            LoopEvaluator.action(currentTime: 1, loopStart: 3, loopEnd: 8),
+            .none
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Adds the practice-workflow core: set A and B, loop that region, save as a named marker with a preferred speed, recall it later.

- \`PracticePlayerViewModel\` grows loop state and \`applyMarker\`; time observer consults a pure \`LoopEvaluator\` helper every tick and seeks with zero tolerance when the playhead crosses end
- Scrubber renders the loop region as an accent-soft capsule with pink edge markers
- A / B / Save / Clear controls sit just below the scrubber
- \`SaveMarkerSheet\` is a Form with label + read-only region + speed pills; speed defaults to the player's current speed
- Saved markers appear as a horizontal scroll of chips; tap to apply (start + end + preferredSpeed restored), context-menu to delete

## Test plan

- [x] \`LoopEvaluatorTests\` covers nil / half / degenerate / inside / at-end / past-end / before
- [ ] CI green
- [ ] Maintainer, on device:
  - [ ] Set A, then B while playing → scrubber highlights the region
  - [ ] Crossing B auto-seeks to A within ~100ms
  - [ ] Save → marker chip appears; tap chip restores both endpoints and speed
  - [ ] Clear wipes the region and stops looping
  - [ ] Context-menu delete removes the marker
  - [ ] Marker persists across app relaunches

Closes #6