### PR TITLE
Frame stepping + mirror mode (#7)

### DIFF
--- a/StepBack/Services/PracticePlayerViewModel.swift
+++ b/StepBack/Services/PracticePlayerViewModel.swift
@@ -15,8 +15,14 @@ final class PracticePlayerViewModel: ObservableObject {
     @Published private(set) var loopStart: Double?
     @Published private(set) var loopEnd: Double?
 
+    @Published var mirrored: Bool = false
+
     let player: AVPlayer
-    private var timeObserver: Any?
+
+    // `timeObserver` is written once in init and read once in deinit — both
+    // outside the normal actor-isolated execution path — so it is marked
+    // nonisolated(unsafe) rather than dragged through MainActor.
+    private nonisolated(unsafe) var timeObserver: Any?
     private var playerItem: AVPlayerItem?
 
     private let assetIdentifier: String
@@ -83,6 +89,29 @@ final class PracticePlayerViewModel: ObservableObject {
         }
     }
 
+    // MARK: - Frame stepping
+
+    func stepForward() { step(by: 1) }
+    func stepBackward() { step(by: -1) }
+
+    private func step(by count: Int) {
+        if isPlaying {
+            player.pause()
+            isPlaying = false
+        }
+        player.currentItem?.step(byCount: count)
+        let seconds = player.currentTime().seconds
+        if seconds.isFinite {
+            currentTime = max(0, min(seconds, duration))
+        }
+    }
+
+    // MARK: - Mirror
+
+    func toggleMirror() {
+        mirrored.toggle()
+    }
+
     // MARK: - A/B loop
 
     var hasLoopRegion: Bool {
@@ -125,19 +154,22 @@ final class PracticePlayerViewModel: ObservableObject {
             forInterval: interval,
             queue: .main
         ) { [weak self] time in
-            guard let self else { return }
-            let seconds = time.seconds
-            if seconds.isFinite {
-                self.currentTime = seconds
-                if case .seek(let target) = LoopEvaluator.action(
-                    currentTime: seconds,
-                    loopStart: self.loopStart,
-                    loopEnd: self.loopEnd
-                ) {
-                    self.seek(to: target)
+            // queue: .main guarantees we are on the main thread here.
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                let seconds = time.seconds
+                if seconds.isFinite {
+                    self.currentTime = seconds
+                    if case .seek(let target) = LoopEvaluator.action(
+                        currentTime: seconds,
+                        loopStart: self.loopStart,
+                        loopEnd: self.loopEnd
+                    ) {
+                        self.seek(to: target)
+                    }
                 }
+                self.isPlaying = self.player.rate > 0
             }
-            self.isPlaying = self.player.rate > 0
         }
     }
 }

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -28,6 +28,20 @@ struct PracticeView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(Theme.Color.background, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    vm.toggleMirror()
+                } label: {
+                    Image(systemName: vm.mirrored
+                        ? "rectangle.portrait.on.rectangle.portrait.angled.fill"
+                        : "rectangle.portrait.on.rectangle.portrait.angled"
+                    )
+                    .foregroundStyle(vm.mirrored ? Theme.Color.accent : Theme.Color.textPrimary)
+                }
+                .accessibilityLabel(vm.mirrored ? "Unmirror video" : "Mirror video")
+            }
+        }
         .task { await vm.load() }
         .sheet(isPresented: $markerSheetPresented) {
             SaveMarkerSheet(
@@ -68,6 +82,7 @@ struct PracticeView: View {
         } else {
             VStack(spacing: 0) {
                 PlayerSurface(player: vm.player)
+                    .scaleEffect(x: vm.mirrored ? -1 : 1, y: 1)
                     .aspectRatio(16.0 / 9.0, contentMode: .fit)
                     .background(Color.black)
                 controls
@@ -112,8 +127,11 @@ struct PracticeView: View {
                     .foregroundStyle(Theme.Color.textSecondary)
             }
             loopControls
-            HStack {
+            HStack(spacing: 32) {
                 Spacer()
+                FrameStepButton(systemName: "backward.frame.fill") {
+                    vm.stepBackward()
+                }
                 Button {
                     vm.togglePlayPause()
                 } label: {
@@ -124,6 +142,9 @@ struct PracticeView: View {
                         .background(Theme.Color.accent, in: Circle())
                 }
                 .buttonStyle(.plain)
+                FrameStepButton(systemName: "forward.frame.fill") {
+                    vm.stepForward()
+                }
                 Spacer()
             }
             SpeedPills(selected: vm.speed, onSelect: vm.setSpeed(_:))
@@ -302,6 +323,23 @@ private struct SpeedPills: View {
                 .buttonStyle(.plain)
             }
         }
+    }
+}
+
+// MARK: - Frame step
+
+private struct FrameStepButton: View {
+    let systemName: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 26, weight: .semibold))
+                .foregroundStyle(Theme.Color.textPrimary)
+                .frame(width: 44, height: 44)
+        }
+        .buttonStyle(.plain)
     }
 }
 


### PR DESCRIPTION
## Summary

- \`stepForward\` / \`stepBackward\` pause then call \`AVPlayerItem.step(byCount: ±1)\` — true frame stepping, not a \`seek(±0.033s)\` that drifts with variable frame rates
- Mirror toggle in the trailing nav slot applies \`.scaleEffect(x: -1, y: 1)\` to the player surface only; controls stay the right way around
- Cleans up the Swift 6 actor-isolation warnings carried over from #6:
  - time-observer body wrapped in \`MainActor.assumeIsolated\` (safe because we pass \`queue: .main\` when registering)
  - \`timeObserver\` is \`nonisolated(unsafe)\` — the right escape hatch for a write-once observer token touched from \`deinit\`

Fulfills the **first v1 milestone end** — the app now has the full core practice loop per the spec ("v1 complete, use it for a few days").

## Test plan

- [ ] CI green
- [ ] Maintainer, on device:
  - [ ] Tapping ⏮/⏭ advances by a single frame, regardless of current play state (pauses if playing)
  - [ ] Repeated steps accumulate smoothly without skips
  - [ ] Mirror toggle flips the video horizontally but leaves scrubber and controls unmirrored
  - [ ] No new console warnings about actor isolation

Closes #7