### PR TITLE
Tags + AutoTagService (#8)

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1724638BD2B70699A591FE9B /* AutoTagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CA1B5B91B8D4637FEEF872 /* AutoTagService.swift */; };
 		1EC09265A1CD5B1E67415B39 /* StepBackApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023608F63978F9D1668F5AFC /* StepBackApp.swift */; };
 		1F02ADF6471B01E48A824A49 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6745FF48B10D28A5ED4BB568 /* Models.swift */; };
 		527B9B596B00D2C774173ECA /* PracticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35AE6C8D6564306E1B0ADA20 /* PracticeView.swift */; };
@@ -15,6 +16,7 @@
 		9F90D5641396A9BF3E7A09FE /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E94F050959741028A8574D /* RootView.swift */; };
 		A49A15759EECD46EC5E3A694 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D07843122196F5F0DA539D1 /* Theme.swift */; };
 		A88000A1ACD9503F7A9D6143 /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB30650146433E889DC2AF4 /* LibraryView.swift */; };
+		B3A98425CA93181D0723AB60 /* AutoTagServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C54B956DF5DE01C00D95680 /* AutoTagServiceTests.swift */; };
 		BE33E08127A1601493FB7837 /* LoopEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57317F752B65258CB2D04530 /* LoopEvaluatorTests.swift */; };
 		C376AB20647940A9E53A89D0 /* ModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848D52E156E709AA0226CEE8 /* ModelsTests.swift */; };
 		C97E59DA25A51E16ECA03607 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C112AEA59633E85CF8267D /* ThemeTests.swift */; };
@@ -36,6 +38,7 @@
 
 /* Begin PBXFileReference section */
 		023608F63978F9D1668F5AFC /* StepBackApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepBackApp.swift; sourceTree = "<group>"; };
+		0C54B956DF5DE01C00D95680 /* AutoTagServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoTagServiceTests.swift; sourceTree = "<group>"; };
 		16E676751B59ED083837CE39 /* SpeedFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedFormatterTests.swift; sourceTree = "<group>"; };
 		2D07843122196F5F0DA539D1 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		35AE6C8D6564306E1B0ADA20 /* PracticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeView.swift; sourceTree = "<group>"; };
@@ -48,6 +51,7 @@
 		848D52E156E709AA0226CEE8 /* ModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsTests.swift; sourceTree = "<group>"; };
 		8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryFormatterTests.swift; sourceTree = "<group>"; };
 		90115F7F368CDD3B0832B3B3 /* Generated-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Generated-Info.plist"; sourceTree = "<group>"; };
+		99CA1B5B91B8D4637FEEF872 /* AutoTagService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoTagService.swift; sourceTree = "<group>"; };
 		A3776C829FB11907CC7E87F9 /* StepBack.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = StepBack.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AAB30650146433E889DC2AF4 /* LibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryView.swift; sourceTree = "<group>"; };
 		B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosServiceTests.swift; sourceTree = "<group>"; };
@@ -85,6 +89,7 @@
 		AAFDEB01F8F445A32BEBF684 /* StepBackTests */ = {
 			isa = PBXGroup;
 			children = (
+				0C54B956DF5DE01C00D95680 /* AutoTagServiceTests.swift */,
 				8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */,
 				57317F752B65258CB2D04530 /* LoopEvaluatorTests.swift */,
 				848D52E156E709AA0226CEE8 /* ModelsTests.swift */,
@@ -98,6 +103,7 @@
 		BCF6C86F86D208F862212667 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				99CA1B5B91B8D4637FEEF872 /* AutoTagService.swift */,
 				D8F8476EAB523378C1F1E046 /* PhotosService.swift */,
 				543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */,
 			);
@@ -232,6 +238,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1724638BD2B70699A591FE9B /* AutoTagService.swift in Sources */,
 				A88000A1ACD9503F7A9D6143 /* LibraryView.swift in Sources */,
 				1F02ADF6471B01E48A824A49 /* Models.swift in Sources */,
 				F7AD3FACE8B875F1C9DFA310 /* PhotosService.swift in Sources */,
@@ -247,6 +254,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B3A98425CA93181D0723AB60 /* AutoTagServiceTests.swift in Sources */,
 				5F405BD1B2F2EB7F30970683 /* LibraryFormatterTests.swift in Sources */,
 				BE33E08127A1601493FB7837 /* LoopEvaluatorTests.swift in Sources */,
 				C376AB20647940A9E53A89D0 /* ModelsTests.swift in Sources */,

--- a/StepBack/Services/AutoTagService.swift
+++ b/StepBack/Services/AutoTagService.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+enum AutoTagService {
+
+    /// 24 hours between consecutive clips ends a cluster and starts a new one.
+    static let clusterGap: TimeInterval = 24 * 60 * 60
+
+    /// Deterministic palette (hex strings matching Theme accents).
+    private static let palette: [String] = [
+        "#FF3B7F", "#5FE7FF", "#5FFFA8", "#FFA13B",
+        "#C2A2FF", "#FFD93B", "#3BFF9E", "#FF6B9F"
+    ]
+
+    struct ClusterDescriptor: Equatable {
+        /// Indexes back into the input array so the caller can wire clips up.
+        let indices: [Int]
+        let earliest: Date
+        let tagName: String
+        let colorHex: String
+    }
+
+    /// Pure clustering: sorts by date, groups by 24h gap, names each cluster
+    /// "Event: MMM d, yyyy" from the earliest date. Stable color per name.
+    static func cluster(dates: [Date], calendar: Calendar = .current) -> [ClusterDescriptor] {
+        guard !dates.isEmpty else { return [] }
+
+        let indexed = dates.enumerated().sorted { $0.element < $1.element }
+        var clusters: [[(index: Int, date: Date)]] = []
+        var current: [(index: Int, date: Date)] = []
+        var previous: Date?
+
+        for (index, date) in indexed {
+            if let prev = previous, date.timeIntervalSince(prev) > clusterGap {
+                clusters.append(current)
+                current = []
+            }
+            current.append((index: index, date: date))
+            previous = date
+        }
+        if !current.isEmpty {
+            clusters.append(current)
+        }
+
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = calendar.locale ?? Locale.current
+        formatter.dateFormat = "MMM d, yyyy"
+
+        return clusters.map { group in
+            let earliest = group.first?.date ?? Date()
+            let tagName = "Event: \(formatter.string(from: earliest))"
+            return ClusterDescriptor(
+                indices: group.map(\.index),
+                earliest: earliest,
+                tagName: tagName,
+                colorHex: color(for: tagName)
+            )
+        }
+    }
+
+    /// Deterministic color pick: hash the name modulo palette length.
+    static func color(for name: String) -> String {
+        let hash = name.unicodeScalars.reduce(0) { $0 &+ Int($1.value) }
+        return palette[abs(hash) % palette.count]
+    }
+}

--- a/StepBack/Views/LibraryView.swift
+++ b/StepBack/Views/LibraryView.swift
@@ -8,10 +8,12 @@ struct LibraryView: View {
 
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \DanceClip.dateAdded, order: .reverse) private var clips: [DanceClip]
+    @Query(sort: \Tag.name) private var tags: [Tag]
 
     @State private var pickerItems: [PhotosPickerItem] = []
     @State private var importState: ImportState = .idle
     @State private var importError: String?
+    @State private var selectedTagIDs: Set<UUID> = []
 
     private let columns = [GridItem(.adaptive(minimum: 140), spacing: 12)]
     private let photosService: PhotosServicing = PhotosService()
@@ -47,23 +49,41 @@ struct LibraryView: View {
 
     // MARK: - Content
 
+    private var filteredClips: [DanceClip] {
+        guard !selectedTagIDs.isEmpty else { return clips }
+        return clips.filter { clip in
+            clip.tags.contains { selectedTagIDs.contains($0.id) }
+        }
+    }
+
     @ViewBuilder
     private var content: some View {
         if clips.isEmpty {
             emptyState
         } else {
-            ScrollView {
-                LazyVGrid(columns: columns, spacing: 12) {
-                    ForEach(clips) { clip in
-                        NavigationLink {
-                            PracticeView(clip: clip)
-                        } label: {
-                            LibraryCell(clip: clip)
+            VStack(spacing: 0) {
+                if !tags.isEmpty {
+                    TagFilterBar(
+                        tags: tags,
+                        selected: $selectedTagIDs,
+                        countFor: { tag in
+                            clips.filter { $0.tags.contains(where: { $0.id == tag.id }) }.count
                         }
-                        .buttonStyle(.plain)
-                    }
+                    )
                 }
-                .padding(12)
+                ScrollView {
+                    LazyVGrid(columns: columns, spacing: 12) {
+                        ForEach(filteredClips) { clip in
+                            NavigationLink {
+                                PracticeView(clip: clip)
+                            } label: {
+                                LibraryCell(clip: clip)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .padding(12)
+                }
             }
         }
     }
@@ -151,6 +171,37 @@ struct LibraryView: View {
         if imported == 0, importError == nil {
             importError = "No clips imported. Make sure you picked videos, not photos."
         }
+        if imported > 0 {
+            applyAutoTags()
+        }
+    }
+
+    /// Re-runs event clustering over all clips and attaches the resulting
+    /// \`Event: …\` tags. Existing tags are reused by name; new ones are
+    /// inserted. Clips already in the right cluster are left alone.
+    private func applyAutoTags() {
+        let allClips = clips.sorted { $0.dateAdded < $1.dateAdded }
+        let clusters = AutoTagService.cluster(dates: allClips.map(\.dateAdded))
+        for cluster in clusters {
+            let tag = findOrCreateTag(name: cluster.tagName, colorHex: cluster.colorHex)
+            for idx in cluster.indices {
+                let clip = allClips[idx]
+                if !clip.tags.contains(where: { $0.id == tag.id }) {
+                    clip.tags.append(tag)
+                }
+            }
+        }
+        try? modelContext.save()
+    }
+
+    private func findOrCreateTag(name: String, colorHex: String) -> Tag {
+        let descriptor = FetchDescriptor<Tag>(predicate: #Predicate { $0.name == name })
+        if let existing = try? modelContext.fetch(descriptor).first {
+            return existing
+        }
+        let tag = Tag(name: name, colorHex: colorHex)
+        modelContext.insert(tag)
+        return tag
     }
 
     private func importOne(_ item: PhotosPickerItem) async throws {
@@ -251,6 +302,61 @@ private struct LibraryCell: View {
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
             .background(Color.black.opacity(0.55), in: Capsule())
+    }
+}
+
+// MARK: - Tag filter bar
+
+private struct TagFilterBar: View {
+    let tags: [Tag]
+    @Binding var selected: Set<UUID>
+    let countFor: (Tag) -> Int
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(tags) { tag in
+                    let isSelected = selected.contains(tag.id)
+                    let accent = Color(hex: UInt32(tag.colorHex.stripHex, radix: 16) ?? 0xFF3B7F)
+                    Button {
+                        if isSelected {
+                            selected.remove(tag.id)
+                        } else {
+                            selected.insert(tag.id)
+                        }
+                    } label: {
+                        HStack(spacing: 6) {
+                            Circle()
+                                .fill(accent)
+                                .frame(width: 8, height: 8)
+                            Text(tag.name)
+                                .font(.system(.footnote, design: .rounded, weight: .semibold))
+                            Text("\(countFor(tag))")
+                                .font(.system(.footnote, design: .monospaced))
+                                .foregroundStyle(Theme.Color.textTertiary)
+                        }
+                        .foregroundStyle(isSelected ? .black : Theme.Color.textPrimary)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(
+                            Capsule().fill(isSelected ? accent : Theme.Color.surfaceElevated)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+        }
+        .background(Theme.Color.background)
+    }
+}
+
+private extension String {
+    /// Strips a leading `#` and returns the hex remainder suitable for
+    /// `Int(_:radix:)` parsing.
+    var stripHex: Substring {
+        hasPrefix("#") ? dropFirst() : Substring(self)
     }
 }
 

--- a/StepBackTests/AutoTagServiceTests.swift
+++ b/StepBackTests/AutoTagServiceTests.swift
@@ -1,0 +1,75 @@
+@testable import StepBack
+import XCTest
+
+final class AutoTagServiceTests: XCTestCase {
+
+    private func date(_ year: Int, _ month: Int, _ day: Int, hour: Int = 12) -> Date {
+        var comp = DateComponents()
+        comp.year = year
+        comp.month = month
+        comp.day = day
+        comp.hour = hour
+        comp.timeZone = TimeZone(secondsFromGMT: 0)
+        return Calendar(identifier: .gregorian).date(from: comp)!
+    }
+
+    func testEmptyReturnsEmpty() {
+        XCTAssertTrue(AutoTagService.cluster(dates: []).isEmpty)
+    }
+
+    func testSingleDateYieldsOneCluster() {
+        let dates = [date(2026, 4, 20)]
+        let clusters = AutoTagService.cluster(dates: dates)
+        XCTAssertEqual(clusters.count, 1)
+        XCTAssertEqual(clusters[0].indices, [0])
+        XCTAssertTrue(clusters[0].tagName.hasPrefix("Event: "))
+    }
+
+    func testClipsSameDaySameCluster() {
+        let dates = [
+            date(2026, 4, 20, hour: 9),
+            date(2026, 4, 20, hour: 18),
+            date(2026, 4, 20, hour: 21)
+        ]
+        let clusters = AutoTagService.cluster(dates: dates)
+        XCTAssertEqual(clusters.count, 1)
+        XCTAssertEqual(clusters[0].indices.count, 3)
+    }
+
+    func testGapOverTwentyFourHoursSplitsClusters() {
+        let dates = [
+            date(2026, 4, 20, hour: 9),
+            // Exactly 25 hours later — past the 24h gap
+            date(2026, 4, 21, hour: 10),
+            date(2026, 4, 21, hour: 22)
+        ]
+        let clusters = AutoTagService.cluster(dates: dates)
+        XCTAssertEqual(clusters.count, 2)
+        XCTAssertEqual(clusters[0].indices, [0])
+        XCTAssertEqual(clusters[1].indices, [1, 2])
+    }
+
+    func testClusterIsIndexedBackToOriginalOrder() {
+        // Out-of-order input: cluster() sorts internally but preserves original
+        // indices so the caller can wire clips[index] back up.
+        let dates = [
+            date(2026, 4, 25, hour: 10), // index 0, later date
+            date(2026, 4, 20, hour: 10)  // index 1, earlier date
+        ]
+        let clusters = AutoTagService.cluster(dates: dates)
+        XCTAssertEqual(clusters.count, 2)
+        // First cluster (by date) should reference the earlier clip, which is index 1
+        XCTAssertEqual(clusters[0].indices, [1])
+        XCTAssertEqual(clusters[1].indices, [0])
+    }
+
+    func testTagColorIsDeterministicPerName() {
+        let first = AutoTagService.color(for: "Event: Apr 20, 2026")
+        let second = AutoTagService.color(for: "Event: Apr 20, 2026")
+        XCTAssertEqual(first, second)
+        XCTAssertNotEqual(
+            AutoTagService.color(for: "Event: Apr 20, 2026"),
+            AutoTagService.color(for: "Event: Dec 31, 2099")
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- \`AutoTagService.cluster(dates:)\` is a pure function: sorts by date, splits on any gap > 24h, labels each cluster \`Event: MMM d, yyyy\` from its earliest date, and hashes the name into an 8-color palette so each event gets a stable chip color
- Returns \`ClusterDescriptor\` with indices back into the original array so the caller can wire clips to tags correctly even when the input is unsorted
- LibraryView runs \`applyAutoTags()\` after every import batch — reuses existing tags by name, inserts missing ones, leaves already-tagged clips alone
- \`TagFilterBar\` is a horizontal scroll of colored chips with live counts; tapping toggles selection (multi-select = OR filter)

## Test plan

- [x] \`AutoTagServiceTests\` covers empty, same-day grouping, > 24h split, out-of-order input, and deterministic color
- [ ] CI green
- [ ] On device:
  - [ ] Import 3 clips on the same day → one chip labeled by that date
  - [ ] Import two batches > 24h apart → two chips, each with its own color, counts correct
  - [ ] Tap chip → grid filters; tap again → unfilters
  - [ ] Tag chip color is stable across app relaunches (it's derived from the name, not random)

Closes #8