### PR TITLE
CompareView: side-by-side synced playback (#9)

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		A49A15759EECD46EC5E3A694 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D07843122196F5F0DA539D1 /* Theme.swift */; };
 		A88000A1ACD9503F7A9D6143 /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB30650146433E889DC2AF4 /* LibraryView.swift */; };
 		B3A98425CA93181D0723AB60 /* AutoTagServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C54B956DF5DE01C00D95680 /* AutoTagServiceTests.swift */; };
+		B6CB4CFDF1EB16757B0D78AA /* CompareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D24FDCCE45AEFB352C5EBF /* CompareView.swift */; };
 		BE33E08127A1601493FB7837 /* LoopEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57317F752B65258CB2D04530 /* LoopEvaluatorTests.swift */; };
 		C376AB20647940A9E53A89D0 /* ModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848D52E156E709AA0226CEE8 /* ModelsTests.swift */; };
 		C97E59DA25A51E16ECA03607 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C112AEA59633E85CF8267D /* ThemeTests.swift */; };
@@ -51,6 +52,7 @@
 		848D52E156E709AA0226CEE8 /* ModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsTests.swift; sourceTree = "<group>"; };
 		8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryFormatterTests.swift; sourceTree = "<group>"; };
 		90115F7F368CDD3B0832B3B3 /* Generated-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Generated-Info.plist"; sourceTree = "<group>"; };
+		92D24FDCCE45AEFB352C5EBF /* CompareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompareView.swift; sourceTree = "<group>"; };
 		99CA1B5B91B8D4637FEEF872 /* AutoTagService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoTagService.swift; sourceTree = "<group>"; };
 		A3776C829FB11907CC7E87F9 /* StepBack.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = StepBack.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AAB30650146433E889DC2AF4 /* LibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryView.swift; sourceTree = "<group>"; };
@@ -79,6 +81,7 @@
 		2BAE89F5B3212B0E382D6904 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				92D24FDCCE45AEFB352C5EBF /* CompareView.swift */,
 				AAB30650146433E889DC2AF4 /* LibraryView.swift */,
 				35AE6C8D6564306E1B0ADA20 /* PracticeView.swift */,
 				56E94F050959741028A8574D /* RootView.swift */,
@@ -239,6 +242,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1724638BD2B70699A591FE9B /* AutoTagService.swift in Sources */,
+				B6CB4CFDF1EB16757B0D78AA /* CompareView.swift in Sources */,
 				A88000A1ACD9503F7A9D6143 /* LibraryView.swift in Sources */,
 				1F02ADF6471B01E48A824A49 /* Models.swift in Sources */,
 				F7AD3FACE8B875F1C9DFA310 /* PhotosService.swift in Sources */,

--- a/StepBack/Models/Models.swift
+++ b/StepBack/Models/Models.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftData
 
 @Model
-final class DanceClip {
+final class DanceClip: Equatable, Hashable {
     var id: UUID
     var title: String
     var assetIdentifier: String
@@ -35,6 +35,14 @@ final class DanceClip {
         self.notes = notes
         self.thumbnailData = thumbnailData
         self.durationSeconds = durationSeconds
+    }
+
+    static func == (lhs: DanceClip, rhs: DanceClip) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
     }
 }
 

--- a/StepBack/Services/AutoTagService.swift
+++ b/StepBack/Services/AutoTagService.swift
@@ -24,17 +24,18 @@ enum AutoTagService {
     static func cluster(dates: [Date], calendar: Calendar = .current) -> [ClusterDescriptor] {
         guard !dates.isEmpty else { return [] }
 
-        let indexed = dates.enumerated().sorted { $0.element < $1.element }
+        let sortedIndices = dates.indices.sorted { dates[$0] < dates[$1] }
         var clusters: [[(index: Int, date: Date)]] = []
         var current: [(index: Int, date: Date)] = []
         var previous: Date?
 
-        for (index, date) in indexed {
+        for originalIndex in sortedIndices {
+            let date = dates[originalIndex]
             if let prev = previous, date.timeIntervalSince(prev) > clusterGap {
                 clusters.append(current)
                 current = []
             }
-            current.append((index: index, date: date))
+            current.append((index: originalIndex, date: date))
             previous = date
         }
         if !current.isEmpty {

--- a/StepBack/Services/PracticePlayerViewModel.swift
+++ b/StepBack/Services/PracticePlayerViewModel.swift
@@ -66,13 +66,25 @@ final class PracticePlayerViewModel: ObservableObject {
     // MARK: - Transport
 
     func togglePlayPause() {
-        if isPlaying {
-            player.pause()
-            isPlaying = false
-        } else {
-            player.playImmediately(atRate: Float(speed))
-            isPlaying = true
-        }
+        if isPlaying { pause() } else { play() }
+    }
+
+    func play() {
+        player.playImmediately(atRate: Float(speed))
+        isPlaying = true
+    }
+
+    func pause() {
+        player.pause()
+        isPlaying = false
+    }
+
+    func restart() {
+        seek(to: 0)
+    }
+
+    func setMuted(_ muted: Bool) {
+        player.isMuted = muted
     }
 
     func seek(to seconds: Double) {

--- a/StepBack/Views/CompareView.swift
+++ b/StepBack/Views/CompareView.swift
@@ -1,0 +1,249 @@
+import AVFoundation
+import SwiftData
+import SwiftUI
+import UIKit
+
+struct CompareView: View {
+
+    let primaryClip: DanceClip
+    let secondaryClip: DanceClip
+
+    @StateObject private var primary: PracticePlayerViewModel
+    @StateObject private var secondary: PracticePlayerViewModel
+
+    @State private var speed: Double = 1.0
+    @State private var primaryMirrored: Bool = false
+    @State private var secondaryMirrored: Bool = false
+
+    init(primary: DanceClip, secondary: DanceClip) {
+        self.primaryClip = primary
+        self.secondaryClip = secondary
+        _primary = StateObject(
+            wrappedValue: PracticePlayerViewModel(assetIdentifier: primary.assetIdentifier)
+        )
+        _secondary = StateObject(
+            wrappedValue: PracticePlayerViewModel(assetIdentifier: secondary.assetIdentifier)
+        )
+    }
+
+    var body: some View {
+        GeometryReader { geo in
+            let isLandscape = geo.size.width > geo.size.height
+            ZStack {
+                Theme.Color.background.ignoresSafeArea()
+                VStack(spacing: 16) {
+                    if isLandscape {
+                        HStack(spacing: 12) {
+                            panel(for: primary, clip: primaryClip, mirrored: $primaryMirrored)
+                            panel(for: secondary, clip: secondaryClip, mirrored: $secondaryMirrored)
+                        }
+                    } else {
+                        VStack(spacing: 12) {
+                            panel(for: primary, clip: primaryClip, mirrored: $primaryMirrored)
+                            panel(for: secondary, clip: secondaryClip, mirrored: $secondaryMirrored)
+                        }
+                    }
+                    sharedControls
+                }
+                .padding(12)
+            }
+        }
+        .navigationTitle("Compare")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(Theme.Color.background, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .task {
+            async let left: () = primary.load()
+            async let right: () = secondary.load()
+            _ = await (left, right)
+            secondary.setMuted(true)
+        }
+        .onDisappear {
+            primary.pause()
+            secondary.pause()
+        }
+    }
+
+    // MARK: - Panels
+
+    private func panel(
+        for viewModel: PracticePlayerViewModel,
+        clip: DanceClip,
+        mirrored: Binding<Bool>
+    ) -> some View {
+        VStack(spacing: 6) {
+            ZStack(alignment: .topTrailing) {
+                ComparePlayerSurface(player: viewModel.player)
+                    .scaleEffect(x: mirrored.wrappedValue ? -1 : 1, y: 1)
+                    .aspectRatio(16.0 / 9.0, contentMode: .fit)
+                    .background(Color.black)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                Button {
+                    mirrored.wrappedValue.toggle()
+                } label: {
+                    Image(systemName: mirrored.wrappedValue
+                        ? "rectangle.portrait.on.rectangle.portrait.angled.fill"
+                        : "rectangle.portrait.on.rectangle.portrait.angled"
+                    )
+                    .foregroundStyle(mirrored.wrappedValue ? Theme.Color.accent : .white)
+                    .padding(8)
+                    .background(Color.black.opacity(0.55), in: Circle())
+                }
+                .buttonStyle(.plain)
+                .padding(8)
+                .accessibilityLabel(mirrored.wrappedValue ? "Unmirror" : "Mirror")
+            }
+            HStack {
+                Text(clip.title)
+                    .font(Theme.Font.caption)
+                    .foregroundStyle(Theme.Color.textSecondary)
+                    .lineLimit(1)
+                Spacer()
+                Text(SpeedFormatter.timestamp(viewModel.currentTime))
+                    .font(Theme.Font.timestamp)
+                    .foregroundStyle(Theme.Color.textTertiary)
+            }
+        }
+    }
+
+    // MARK: - Shared controls
+
+    private var sharedControls: some View {
+        VStack(spacing: 14) {
+            HStack(spacing: 32) {
+                Spacer()
+                Button {
+                    primary.restart()
+                    secondary.restart()
+                } label: {
+                    Image(systemName: "backward.end.fill")
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundStyle(Theme.Color.textPrimary)
+                        .frame(width: 44, height: 44)
+                }
+                .buttonStyle(.plain)
+                Button {
+                    togglePlayPauseBoth()
+                } label: {
+                    Image(systemName: anyPlaying ? "pause.fill" : "play.fill")
+                        .font(.system(size: 26, weight: .semibold))
+                        .foregroundStyle(.black)
+                        .frame(width: 64, height: 64)
+                        .background(Theme.Color.accent, in: Circle())
+                }
+                .buttonStyle(.plain)
+                Spacer()
+            }
+            SpeedPills(selected: speed, onSelect: setSpeed)
+        }
+    }
+
+    private var anyPlaying: Bool { primary.isPlaying || secondary.isPlaying }
+
+    private func togglePlayPauseBoth() {
+        if anyPlaying {
+            primary.pause()
+            secondary.pause()
+        } else {
+            primary.setSpeed(speed)
+            secondary.setSpeed(speed)
+            primary.play()
+            secondary.play()
+        }
+    }
+
+    private func setSpeed(_ newSpeed: Double) {
+        speed = newSpeed
+        primary.setSpeed(newSpeed)
+        secondary.setSpeed(newSpeed)
+    }
+}
+
+// MARK: - Internal player surface (duplicated to keep PracticeView's private)
+
+private struct ComparePlayerSurface: UIViewRepresentable {
+    let player: AVPlayer
+
+    func makeUIView(context: Context) -> CompareLayerView {
+        let view = CompareLayerView()
+        view.playerLayer.player = player
+        view.playerLayer.videoGravity = .resizeAspect
+        return view
+    }
+
+    func updateUIView(_ uiView: CompareLayerView, context: Context) {
+        uiView.playerLayer.player = player
+    }
+}
+
+private final class CompareLayerView: UIView {
+    override static var layerClass: AnyClass { AVPlayerLayer.self }
+
+    var playerLayer: AVPlayerLayer {
+        guard let layer = layer as? AVPlayerLayer else {
+            preconditionFailure("CompareLayerView.layer must be an AVPlayerLayer")
+        }
+        return layer
+    }
+}
+
+// MARK: - Picker sheet
+
+struct CompareClipPicker: View {
+    let excludedID: UUID
+    let onPick: (DanceClip) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @Query(sort: \DanceClip.dateAdded, order: .reverse) private var clips: [DanceClip]
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(clips.filter { $0.id != excludedID }) { clip in
+                    Button {
+                        onPick(clip)
+                        dismiss()
+                    } label: {
+                        HStack {
+                            thumbnail(for: clip)
+                                .frame(width: 56, height: 40)
+                                .clipShape(RoundedRectangle(cornerRadius: 6))
+                            VStack(alignment: .leading) {
+                                Text(clip.title)
+                                    .font(Theme.Font.bodyEmphasized)
+                                    .foregroundStyle(Theme.Color.textPrimary)
+                                Text(clip.dateAdded, style: .date)
+                                    .font(Theme.Font.caption)
+                                    .foregroundStyle(Theme.Color.textTertiary)
+                            }
+                        }
+                    }
+                    .listRowBackground(Theme.Color.surface)
+                }
+            }
+            .scrollContentBackground(.hidden)
+            .background(Theme.Color.background)
+            .navigationTitle("Pick a clip to compare")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+        .preferredColorScheme(.dark)
+    }
+
+    @ViewBuilder
+    private func thumbnail(for clip: DanceClip) -> some View {
+        if let data = clip.thumbnailData, let uiImage = UIImage(data: data) {
+            Image(uiImage: uiImage).resizable().scaledToFill()
+        } else {
+            ZStack {
+                Theme.Color.surfaceElevated
+                Image(systemName: "film")
+                    .foregroundStyle(Theme.Color.textTertiary)
+            }
+        }
+    }
+}

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -316,7 +316,7 @@ private struct Scrubber: View {
 
 // MARK: - Speed pills
 
-private struct SpeedPills: View {
+struct SpeedPills: View {
     static let speeds: [Double] = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5]
     let selected: Double
     let onSelect: (Double) -> Void

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -11,6 +11,8 @@ struct PracticeView: View {
     @Environment(\.modelContext) private var modelContext
     @StateObject private var vm: PracticePlayerViewModel
     @State private var markerSheetPresented = false
+    @State private var comparePickerPresented = false
+    @State private var compareSecondary: DanceClip?
 
     init(clip: DanceClip) {
         self.clip = clip
@@ -30,19 +32,36 @@ struct PracticeView: View {
         .toolbarColorScheme(.dark, for: .navigationBar)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
-                Button {
-                    vm.toggleMirror()
-                } label: {
-                    Image(systemName: vm.mirrored
-                        ? "rectangle.portrait.on.rectangle.portrait.angled.fill"
-                        : "rectangle.portrait.on.rectangle.portrait.angled"
-                    )
-                    .foregroundStyle(vm.mirrored ? Theme.Color.accent : Theme.Color.textPrimary)
+                HStack(spacing: 8) {
+                    Button {
+                        comparePickerPresented = true
+                    } label: {
+                        Image(systemName: "rectangle.2.swap")
+                            .foregroundStyle(Theme.Color.textPrimary)
+                    }
+                    .accessibilityLabel("Compare with another clip")
+                    Button {
+                        vm.toggleMirror()
+                    } label: {
+                        Image(systemName: vm.mirrored
+                            ? "rectangle.portrait.on.rectangle.portrait.angled.fill"
+                            : "rectangle.portrait.on.rectangle.portrait.angled"
+                        )
+                        .foregroundStyle(vm.mirrored ? Theme.Color.accent : Theme.Color.textPrimary)
+                    }
+                    .accessibilityLabel(vm.mirrored ? "Unmirror video" : "Mirror video")
                 }
-                .accessibilityLabel(vm.mirrored ? "Unmirror video" : "Mirror video")
             }
         }
         .task { await vm.load() }
+        .sheet(isPresented: $comparePickerPresented) {
+            CompareClipPicker(excludedID: clip.id) { picked in
+                compareSecondary = picked
+            }
+        }
+        .navigationDestination(item: $compareSecondary) { secondary in
+            CompareView(primary: clip, secondary: secondary)
+        }
         .sheet(isPresented: $markerSheetPresented) {
             SaveMarkerSheet(
                 defaultSpeed: vm.speed,

--- a/StepBackTests/AutoTagServiceTests.swift
+++ b/StepBackTests/AutoTagServiceTests.swift
@@ -10,7 +10,7 @@ final class AutoTagServiceTests: XCTestCase {
         comp.day = day
         comp.hour = hour
         comp.timeZone = TimeZone(secondsFromGMT: 0)
-        return Calendar(identifier: .gregorian).date(from: comp)!
+        return Calendar(identifier: .gregorian).date(from: comp) ?? Date.distantPast
     }
 
     func testEmptyReturnsEmpty() {


### PR DESCRIPTION
## Summary

Two players, synced transport, one audio track. Entry from PracticeView's toolbar.

- Two \`PracticePlayerViewModel\`s, one per clip — both items get \`audioTimePitchAlgorithm = .timeDomain\` (the easy-to-forget case the spec calls out)
- Shared transport: play/pause drives both, restart seeks both to 0, speed is shared
- Secondary player is muted so the primary's audio carries the beat
- Mirror toggle is per-panel, overlaid on each video
- Orientation-aware layout: stacked vertical in portrait, side-by-side in landscape
- \`DanceClip\` gets explicit \`Equatable\` / \`Hashable\` (by \`id\`) so \`navigationDestination(item:)\` accepts it
- VM gains explicit \`play\` / \`pause\` / \`restart\` / \`setMuted\` so the coordinator doesn't have to guess transport state

## Test plan

- [ ] CI green
- [ ] On device:
  - [ ] Both clips load and display
  - [ ] Play starts both; pause stops both
  - [ ] Speed change applies to both in sync; no pitch-shifting
  - [ ] Restart rewinds both
  - [ ] Only the primary is audible
  - [ ] Mirror toggle flips only its own panel
  - [ ] Rotating the device swaps between stacked and side-by-side layouts

Closes #9