### PR TITLE
Beat fields schema migration (#10)

### DIFF
--- a/StepBack/Models/Models.swift
+++ b/StepBack/Models/Models.swift
@@ -12,6 +12,12 @@ final class DanceClip: Equatable, Hashable {
     var thumbnailData: Data?
     var durationSeconds: Double
 
+    // Beat analysis, populated once by BeatDetector and cached in the store.
+    var bpm: Double?
+    var beatTimesData: Data?
+    var firstDownbeatSeconds: Double?
+    var beatsPerMeasure: Int = 4
+
     @Relationship(deleteRule: .cascade, inverse: \LoopMarker.clip)
     var loopMarkers: [LoopMarker] = []
 
@@ -43,6 +49,27 @@ final class DanceClip: Equatable, Hashable {
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
+    }
+
+    // MARK: - Beat helpers
+
+    /// Decoded beat times (seconds, monotonic). Empty when no analysis exists.
+    var beatTimes: [Double] {
+        guard let data = beatTimesData else { return [] }
+        return (try? JSONDecoder().decode([Double].self, from: data)) ?? []
+    }
+
+    /// Writes beat times back through `beatTimesData`. Empty clears the cache.
+    func setBeatTimes(_ times: [Double]) {
+        if times.isEmpty {
+            beatTimesData = nil
+            return
+        }
+        beatTimesData = try? JSONEncoder().encode(times)
+    }
+
+    var hasBeatAnalysis: Bool {
+        bpm != nil && beatTimesData != nil
     }
 }
 

--- a/StepBackTests/ModelsTests.swift
+++ b/StepBackTests/ModelsTests.swift
@@ -35,6 +35,44 @@ final class ModelsTests: XCTestCase {
         XCTAssertEqual(clip.durationSeconds, 0)
         XCTAssertTrue(clip.loopMarkers.isEmpty)
         XCTAssertTrue(clip.tags.isEmpty)
+
+        // Beat analysis defaults
+        XCTAssertNil(clip.bpm)
+        XCTAssertNil(clip.beatTimesData)
+        XCTAssertNil(clip.firstDownbeatSeconds)
+        XCTAssertEqual(clip.beatsPerMeasure, 4)
+        XCTAssertFalse(clip.hasBeatAnalysis)
+        XCTAssertEqual(clip.beatTimes, [])
+    }
+
+    // MARK: - Beat helpers
+
+    func testBeatTimesRoundTrip() throws {
+        let clip = DanceClip(title: "Beats", assetIdentifier: "B-1")
+        context.insert(clip)
+
+        let beats = [0.1, 0.6, 1.1, 1.6, 2.1]
+        clip.setBeatTimes(beats)
+        clip.bpm = 120
+        try context.save()
+
+        XCTAssertEqual(clip.beatTimes, beats)
+        XCTAssertTrue(clip.hasBeatAnalysis)
+    }
+
+    func testSetBeatTimesEmptyClearsCache() throws {
+        let clip = DanceClip(title: "Beats", assetIdentifier: "B-2")
+        clip.setBeatTimes([1, 2, 3])
+        XCTAssertNotNil(clip.beatTimesData)
+        clip.setBeatTimes([])
+        XCTAssertNil(clip.beatTimesData)
+        XCTAssertEqual(clip.beatTimes, [])
+    }
+
+    func testCorruptBeatTimesDataYieldsEmptyArray() {
+        let clip = DanceClip(title: "Corrupt", assetIdentifier: "B-3")
+        clip.beatTimesData = Data([0xFF, 0x00, 0x42])
+        XCTAssertEqual(clip.beatTimes, [])
     }
 
     // MARK: - LoopMarker


### PR DESCRIPTION
## Summary

Extends \`DanceClip\` with optional beat-analysis state. All new fields are optional or have defaults, which is what lets SwiftData migrate an existing store without intervention.

- \`bpm: Double?\`
- \`beatTimesData: Data?\` (JSON-encoded \`[Double]\`)
- \`firstDownbeatSeconds: Double?\`
- \`beatsPerMeasure: Int\` (default 4)
- Computed \`beatTimes\` decodes \`beatTimesData\`; \`setBeatTimes(_:)\` re-encodes and clears cleanly on empty input
- Computed \`hasBeatAnalysis\` gates the beat UI that #12 adds

## Test plan

- [x] \`ModelsTests\` covers defaults, round-trip encode/decode, empty clears the blob, corrupt data degrades to empty array
- [ ] CI green
- [ ] Maintainer: open app with existing library → clips still render, no crash (SwiftData migration happens silently because fields are optional)

Closes #10