### PR TITLE
Beat UI: ticks, BPM badge, count, downbeat anchor (#12)

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -7,11 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		03C973FD27336E9DD2EDE507 /* PracticeBeatUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6BAE20433D2ED45F00AD41 /* PracticeBeatUI.swift */; };
 		1724638BD2B70699A591FE9B /* AutoTagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CA1B5B91B8D4637FEEF872 /* AutoTagService.swift */; };
 		1EC09265A1CD5B1E67415B39 /* StepBackApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023608F63978F9D1668F5AFC /* StepBackApp.swift */; };
 		1F02ADF6471B01E48A824A49 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6745FF48B10D28A5ED4BB568 /* Models.swift */; };
 		527B9B596B00D2C774173ECA /* PracticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35AE6C8D6564306E1B0ADA20 /* PracticeView.swift */; };
 		5F405BD1B2F2EB7F30970683 /* LibraryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */; };
+		691A3AE86C110C252A1412FE /* BeatGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078CB839E392E788201DD665 /* BeatGrid.swift */; };
 		76D520F6EC5A0A8E57C8AAA1 /* BeatDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6BC077A9FA8B51D07C178A0 /* BeatDetectorTests.swift */; };
 		7FA3BBA0113FDF3282819E84 /* PracticePlayerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */; };
 		9F90D5641396A9BF3E7A09FE /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E94F050959741028A8574D /* RootView.swift */; };
@@ -24,6 +26,7 @@
 		C97E59DA25A51E16ECA03607 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C112AEA59633E85CF8267D /* ThemeTests.swift */; };
 		CC6F98E7716925F88449689A /* PhotosServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */; };
 		D9873262DD68100D8D3C1021 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 462E264B215595E9EC3D1C4A /* Assets.xcassets */; };
+		DA0EE94353A18DA75824D7A8 /* BeatGridTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7093A077C0A2C139BD7BDD29 /* BeatGridTests.swift */; };
 		E9E06DF791FF47015B3DDFA8 /* BeatDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59BD8F65AE46261EEFD4F69 /* BeatDetector.swift */; };
 		F35848C14CA3DF06A4EBE554 /* SpeedFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E676751B59ED083837CE39 /* SpeedFormatterTests.swift */; };
 		F7AD3FACE8B875F1C9DFA310 /* PhotosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F8476EAB523378C1F1E046 /* PhotosService.swift */; };
@@ -41,6 +44,7 @@
 
 /* Begin PBXFileReference section */
 		023608F63978F9D1668F5AFC /* StepBackApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepBackApp.swift; sourceTree = "<group>"; };
+		078CB839E392E788201DD665 /* BeatGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeatGrid.swift; sourceTree = "<group>"; };
 		0C54B956DF5DE01C00D95680 /* AutoTagServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoTagServiceTests.swift; sourceTree = "<group>"; };
 		16E676751B59ED083837CE39 /* SpeedFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedFormatterTests.swift; sourceTree = "<group>"; };
 		2D07843122196F5F0DA539D1 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
@@ -51,6 +55,7 @@
 		56E94F050959741028A8574D /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		57317F752B65258CB2D04530 /* LoopEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopEvaluatorTests.swift; sourceTree = "<group>"; };
 		6745FF48B10D28A5ED4BB568 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
+		7093A077C0A2C139BD7BDD29 /* BeatGridTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeatGridTests.swift; sourceTree = "<group>"; };
 		848D52E156E709AA0226CEE8 /* ModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsTests.swift; sourceTree = "<group>"; };
 		8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryFormatterTests.swift; sourceTree = "<group>"; };
 		90115F7F368CDD3B0832B3B3 /* Generated-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Generated-Info.plist"; sourceTree = "<group>"; };
@@ -61,6 +66,7 @@
 		B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosServiceTests.swift; sourceTree = "<group>"; };
 		B7C112AEA59633E85CF8267D /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		C59BD8F65AE46261EEFD4F69 /* BeatDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeatDetector.swift; sourceTree = "<group>"; };
+		CC6BAE20433D2ED45F00AD41 /* PracticeBeatUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeBeatUI.swift; sourceTree = "<group>"; };
 		D8F8476EAB523378C1F1E046 /* PhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosService.swift; sourceTree = "<group>"; };
 		F6BC077A9FA8B51D07C178A0 /* BeatDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeatDetectorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -87,6 +93,7 @@
 			children = (
 				92D24FDCCE45AEFB352C5EBF /* CompareView.swift */,
 				AAB30650146433E889DC2AF4 /* LibraryView.swift */,
+				CC6BAE20433D2ED45F00AD41 /* PracticeBeatUI.swift */,
 				35AE6C8D6564306E1B0ADA20 /* PracticeView.swift */,
 				56E94F050959741028A8574D /* RootView.swift */,
 			);
@@ -98,6 +105,7 @@
 			children = (
 				0C54B956DF5DE01C00D95680 /* AutoTagServiceTests.swift */,
 				F6BC077A9FA8B51D07C178A0 /* BeatDetectorTests.swift */,
+				7093A077C0A2C139BD7BDD29 /* BeatGridTests.swift */,
 				8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */,
 				57317F752B65258CB2D04530 /* LoopEvaluatorTests.swift */,
 				848D52E156E709AA0226CEE8 /* ModelsTests.swift */,
@@ -113,6 +121,7 @@
 			children = (
 				99CA1B5B91B8D4637FEEF872 /* AutoTagService.swift */,
 				C59BD8F65AE46261EEFD4F69 /* BeatDetector.swift */,
+				078CB839E392E788201DD665 /* BeatGrid.swift */,
 				D8F8476EAB523378C1F1E046 /* PhotosService.swift */,
 				543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */,
 			);
@@ -249,10 +258,12 @@
 			files = (
 				1724638BD2B70699A591FE9B /* AutoTagService.swift in Sources */,
 				E9E06DF791FF47015B3DDFA8 /* BeatDetector.swift in Sources */,
+				691A3AE86C110C252A1412FE /* BeatGrid.swift in Sources */,
 				B6CB4CFDF1EB16757B0D78AA /* CompareView.swift in Sources */,
 				A88000A1ACD9503F7A9D6143 /* LibraryView.swift in Sources */,
 				1F02ADF6471B01E48A824A49 /* Models.swift in Sources */,
 				F7AD3FACE8B875F1C9DFA310 /* PhotosService.swift in Sources */,
+				03C973FD27336E9DD2EDE507 /* PracticeBeatUI.swift in Sources */,
 				7FA3BBA0113FDF3282819E84 /* PracticePlayerViewModel.swift in Sources */,
 				527B9B596B00D2C774173ECA /* PracticeView.swift in Sources */,
 				9F90D5641396A9BF3E7A09FE /* RootView.swift in Sources */,
@@ -267,6 +278,7 @@
 			files = (
 				B3A98425CA93181D0723AB60 /* AutoTagServiceTests.swift in Sources */,
 				76D520F6EC5A0A8E57C8AAA1 /* BeatDetectorTests.swift in Sources */,
+				DA0EE94353A18DA75824D7A8 /* BeatGridTests.swift in Sources */,
 				5F405BD1B2F2EB7F30970683 /* LibraryFormatterTests.swift in Sources */,
 				BE33E08127A1601493FB7837 /* LoopEvaluatorTests.swift in Sources */,
 				C376AB20647940A9E53A89D0 /* ModelsTests.swift in Sources */,

--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1724638BD2B70699A591FE9B /* AutoTagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CA1B5B91B8D4637FEEF872 /* AutoTagService.swift */; };
 		1EC09265A1CD5B1E67415B39 /* StepBackApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023608F63978F9D1668F5AFC /* StepBackApp.swift */; };
 		1F02ADF6471B01E48A824A49 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6745FF48B10D28A5ED4BB568 /* Models.swift */; };
+		2B90619AE0B5262B774DEAC1 /* PracticeControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35987D9825155E131A40950 /* PracticeControls.swift */; };
 		527B9B596B00D2C774173ECA /* PracticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35AE6C8D6564306E1B0ADA20 /* PracticeView.swift */; };
 		5F405BD1B2F2EB7F30970683 /* LibraryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */; };
 		691A3AE86C110C252A1412FE /* BeatGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078CB839E392E788201DD665 /* BeatGrid.swift */; };
@@ -65,6 +66,7 @@
 		AAB30650146433E889DC2AF4 /* LibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryView.swift; sourceTree = "<group>"; };
 		B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosServiceTests.swift; sourceTree = "<group>"; };
 		B7C112AEA59633E85CF8267D /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
+		C35987D9825155E131A40950 /* PracticeControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeControls.swift; sourceTree = "<group>"; };
 		C59BD8F65AE46261EEFD4F69 /* BeatDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeatDetector.swift; sourceTree = "<group>"; };
 		CC6BAE20433D2ED45F00AD41 /* PracticeBeatUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeBeatUI.swift; sourceTree = "<group>"; };
 		D8F8476EAB523378C1F1E046 /* PhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosService.swift; sourceTree = "<group>"; };
@@ -94,6 +96,7 @@
 				92D24FDCCE45AEFB352C5EBF /* CompareView.swift */,
 				AAB30650146433E889DC2AF4 /* LibraryView.swift */,
 				CC6BAE20433D2ED45F00AD41 /* PracticeBeatUI.swift */,
+				C35987D9825155E131A40950 /* PracticeControls.swift */,
 				35AE6C8D6564306E1B0ADA20 /* PracticeView.swift */,
 				56E94F050959741028A8574D /* RootView.swift */,
 			);
@@ -264,6 +267,7 @@
 				1F02ADF6471B01E48A824A49 /* Models.swift in Sources */,
 				F7AD3FACE8B875F1C9DFA310 /* PhotosService.swift in Sources */,
 				03C973FD27336E9DD2EDE507 /* PracticeBeatUI.swift in Sources */,
+				2B90619AE0B5262B774DEAC1 /* PracticeControls.swift in Sources */,
 				7FA3BBA0113FDF3282819E84 /* PracticePlayerViewModel.swift in Sources */,
 				527B9B596B00D2C774173ECA /* PracticeView.swift in Sources */,
 				9F90D5641396A9BF3E7A09FE /* RootView.swift in Sources */,

--- a/StepBack/Services/BeatGrid.swift
+++ b/StepBack/Services/BeatGrid.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// Pure helpers for reasoning about a cached beat grid. All functions here
+/// are value-in / value-out so they can be tested without an AVPlayer.
+enum BeatGrid {
+
+    /// Closest beat index to `time`. Returns `nil` if `beatTimes` is empty.
+    static func nearestBeatIndex(to time: Double, in beatTimes: [Double]) -> Int? {
+        guard !beatTimes.isEmpty else { return nil }
+        // Binary search for the first index whose time >= target.
+        var lower = 0
+        var upper = beatTimes.count
+        while lower < upper {
+            let mid = (lower + upper) / 2
+            if beatTimes[mid] < time { lower = mid + 1 } else { upper = mid }
+        }
+        let before = lower - 1
+        let after = lower
+        let beforeDiff = before >= 0 ? abs(time - beatTimes[before]) : .infinity
+        let afterDiff = after < beatTimes.count ? abs(time - beatTimes[after]) : .infinity
+        return beforeDiff <= afterDiff ? before : after
+    }
+
+    /// Signed offset in milliseconds from `time` to its nearest beat.
+    /// Negative = early (tap came before the beat), positive = late.
+    static func offsetMs(from time: Double, toNearestBeatIn beatTimes: [Double]) -> Double? {
+        guard let idx = nearestBeatIndex(to: time, in: beatTimes) else { return nil }
+        return (time - beatTimes[idx]) * 1_000
+    }
+
+    /// Indices of every downbeat, derived from a user-supplied anchor.
+    /// Finds the beat nearest the anchor and every `beatsPerMeasure`-th beat
+    /// before and after it.
+    static func downbeatIndices(
+        beatTimes: [Double],
+        anchor: Double?,
+        beatsPerMeasure: Int
+    ) -> Set<Int> {
+        guard let anchor, !beatTimes.isEmpty, beatsPerMeasure > 0,
+              let nearest = nearestBeatIndex(to: anchor, in: beatTimes) else {
+            return []
+        }
+        var indices: Set<Int> = []
+        var walk = nearest
+        while walk >= 0 {
+            indices.insert(walk)
+            walk -= beatsPerMeasure
+        }
+        walk = nearest + beatsPerMeasure
+        while walk < beatTimes.count {
+            indices.insert(walk)
+            walk += beatsPerMeasure
+        }
+        return indices
+    }
+
+    /// Current 1-indexed position in the measure (e.g. 1..4 for WCS).
+    /// `nil` when there's no anchor, no beats, or we haven't nearest-found
+    /// a beat for `currentTime`.
+    static func currentMeasurePosition(
+        currentTime: Double,
+        beatTimes: [Double],
+        anchor: Double?,
+        beatsPerMeasure: Int
+    ) -> Int? {
+        guard let anchor,
+              beatsPerMeasure > 0,
+              let currentIndex = nearestBeatIndex(to: currentTime, in: beatTimes),
+              let anchorIndex = nearestBeatIndex(to: anchor, in: beatTimes) else {
+            return nil
+        }
+        let rawOffset = currentIndex - anchorIndex
+        let position = ((rawOffset % beatsPerMeasure) + beatsPerMeasure) % beatsPerMeasure
+        return position + 1
+    }
+
+    /// Rescales an existing beat grid by factor. `factor = 2` doubles the
+    /// grid resolution (inserts midpoints between adjacent beats); `factor
+    /// = 0.5` halves it (keeps every other beat).
+    static func rescale(beatTimes: [Double], factor: Double) -> [Double] {
+        guard beatTimes.count >= 2, factor > 0 else { return beatTimes }
+        if factor == 2 {
+            var result: [Double] = []
+            result.reserveCapacity(beatTimes.count * 2 - 1)
+            for index in 0..<(beatTimes.count - 1) {
+                result.append(beatTimes[index])
+                result.append((beatTimes[index] + beatTimes[index + 1]) / 2)
+            }
+            result.append(beatTimes[beatTimes.count - 1])
+            return result
+        }
+        if factor == 0.5 {
+            return stride(from: 0, to: beatTimes.count, by: 2).map { beatTimes[$0] }
+        }
+        return beatTimes
+    }
+}

--- a/StepBack/Services/PracticePlayerViewModel.swift
+++ b/StepBack/Services/PracticePlayerViewModel.swift
@@ -17,6 +17,9 @@ final class PracticePlayerViewModel: ObservableObject {
 
     @Published var mirrored: Bool = false
 
+    @Published private(set) var isAnalyzingBeats: Bool = false
+    @Published var analysisError: String?
+
     let player: AVPlayer
 
     // `timeObserver` is written once in init and read once in deinit — both
@@ -122,6 +125,42 @@ final class PracticePlayerViewModel: ObservableObject {
 
     func toggleMirror() {
         mirrored.toggle()
+    }
+
+    // MARK: - Beat detection
+
+    /// Runs `BeatDetector` against the currently-loaded asset and writes the
+    /// result back into `clip`. The caller is responsible for persisting the
+    /// model context via `onSave`.
+    func detectBeats(for clip: DanceClip, onSave: @escaping () -> Void) async {
+        guard !isAnalyzingBeats, !clip.hasBeatAnalysis else { return }
+        guard let asset = player.currentItem?.asset else {
+            analysisError = "Clip hasn't finished loading yet."
+            return
+        }
+        isAnalyzingBeats = true
+        analysisError = nil
+        do {
+            let analysis = try await BeatDetector.analyze(asset: asset)
+            clip.bpm = analysis.bpm
+            clip.setBeatTimes(analysis.beatTimes)
+            isAnalyzingBeats = false
+            onSave()
+        } catch {
+            isAnalyzingBeats = false
+            analysisError = error.localizedDescription
+        }
+    }
+
+    /// Marks `currentTime` as beat 1. Caller persists.
+    func tapOnBeatOne(for clip: DanceClip, onSave: @escaping () -> Void) {
+        clip.firstDownbeatSeconds = currentTime
+        onSave()
+    }
+
+    func clearDownbeatAnchor(for clip: DanceClip, onSave: @escaping () -> Void) {
+        clip.firstDownbeatSeconds = nil
+        onSave()
     }
 
     // MARK: - A/B loop

--- a/StepBack/Views/PracticeBeatUI.swift
+++ b/StepBack/Views/PracticeBeatUI.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+// MARK: - BPM badge + detect button
+
+struct BPMBadge: View {
+    let bpm: Double?
+    let isAnalyzing: Bool
+    let measurePosition: Int?
+    let beatsPerMeasure: Int
+    let onDetect: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            if let bpm {
+                Text("\(Int(bpm.rounded())) BPM")
+                    .font(.system(.footnote, design: .rounded, weight: .bold))
+                    .foregroundStyle(Theme.Color.accent)
+                if let measurePosition {
+                    MeasureCounter(current: measurePosition, total: beatsPerMeasure)
+                }
+            } else if isAnalyzing {
+                ProgressView()
+                    .tint(Theme.Color.accent)
+                Text("Detecting beats…")
+                    .font(Theme.Font.caption)
+                    .foregroundStyle(Theme.Color.textSecondary)
+            } else {
+                Button(action: onDetect) {
+                    Label("Detect beats", systemImage: "waveform")
+                        .font(.system(.footnote, design: .rounded, weight: .semibold))
+                        .foregroundStyle(Theme.Color.accent)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Theme.Color.accentSoft, in: Capsule())
+    }
+}
+
+// MARK: - Count-in-measure indicator
+
+struct MeasureCounter: View {
+    let current: Int
+    let total: Int
+
+    var body: some View {
+        HStack(spacing: 4) {
+            ForEach(1...total, id: \.self) { slot in
+                let isCurrent = slot == current
+                Text("\(slot)")
+                    .font(.system(.caption2, design: .rounded, weight: isCurrent ? .black : .regular))
+                    .foregroundStyle(isCurrent ? Theme.Color.accent : Theme.Color.textTertiary)
+                    .frame(width: 14, height: 14)
+                    .background(
+                        Circle()
+                            .fill(isCurrent ? Theme.Color.accent.opacity(0.25) : .clear)
+                    )
+            }
+        }
+    }
+}
+
+// MARK: - Downbeat anchor controls
+
+struct DownbeatAnchorBar: View {
+    let hasAnchor: Bool
+    let onTap: () -> Void
+    let onClear: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            if hasAnchor {
+                Label("Beat 1 locked", systemImage: "checkmark.circle.fill")
+                    .font(.system(.footnote, design: .rounded, weight: .semibold))
+                    .foregroundStyle(Theme.Color.accent)
+                Spacer()
+                Button("Reset", action: onClear)
+                    .font(Theme.Font.caption)
+                    .foregroundStyle(Theme.Color.textTertiary)
+            } else {
+                Button(action: onTap) {
+                    Label("Tap on beat 1", systemImage: "hand.tap")
+                        .font(.system(.footnote, design: .rounded, weight: .semibold))
+                        .foregroundStyle(.black)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 8)
+                        .background(Theme.Color.accent, in: Capsule())
+                }
+                .buttonStyle(.plain)
+                Spacer()
+            }
+        }
+    }
+}

--- a/StepBack/Views/PracticeControls.swift
+++ b/StepBack/Views/PracticeControls.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+// MARK: - Speed pills
+
+struct SpeedPills: View {
+    static let speeds: [Double] = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5]
+    let selected: Double
+    let onSelect: (Double) -> Void
+
+    var body: some View {
+        HStack(spacing: 6) {
+            ForEach(Self.speeds, id: \.self) { speed in
+                let isSelected = SpeedFormatter.equals(selected, speed)
+                let tint = Theme.Color.speedPillColor(for: speed)
+                Button {
+                    onSelect(speed)
+                } label: {
+                    Text(SpeedFormatter.pill(speed))
+                        .font(.system(.footnote, design: .rounded, weight: .semibold))
+                        .foregroundStyle(isSelected ? .black : tint)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(
+                            Capsule()
+                                .fill(isSelected ? tint : Theme.Color.surfaceElevated)
+                        )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}
+
+// MARK: - Formatting
+
+enum SpeedFormatter {
+    static func pill(_ speed: Double) -> String {
+        let base: String
+        if speed == speed.rounded() {
+            base = "\(Int(speed))"
+        } else {
+            base = String(format: "%g", speed)
+        }
+        return "\(base)×"
+    }
+
+    static func timestamp(_ seconds: Double) -> String {
+        guard seconds.isFinite, seconds >= 0 else { return "--:--" }
+        let totalCentis = Int((seconds * 100).rounded())
+        let mins = totalCentis / 6000
+        let secs = (totalCentis / 100) % 60
+        let cent = totalCentis % 100
+        return String(format: "%d:%02d.%02d", mins, secs, cent)
+    }
+
+    static func equals(_ a: Double, _ b: Double) -> Bool {
+        abs(a - b) < 0.001
+    }
+}

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -91,6 +91,24 @@ struct PracticeView: View {
         try? modelContext.save()
     }
 
+    private func detectBeats() async {
+        await vm.detectBeats(for: clip) {
+            try? modelContext.save()
+        }
+    }
+
+    private func tapOnBeatOne() {
+        vm.tapOnBeatOne(for: clip) {
+            try? modelContext.save()
+        }
+    }
+
+    private func clearDownbeat() {
+        vm.clearDownbeatAnchor(for: clip) {
+            try? modelContext.save()
+        }
+    }
+
     @ViewBuilder
     private var content: some View {
         if let error = vm.loadError {
@@ -128,12 +146,42 @@ struct PracticeView: View {
     // MARK: - Controls
 
     private var controls: some View {
-        VStack(spacing: 14) {
+        let downbeats = BeatGrid.downbeatIndices(
+            beatTimes: clip.beatTimes,
+            anchor: clip.firstDownbeatSeconds,
+            beatsPerMeasure: clip.beatsPerMeasure
+        )
+        let measurePosition = BeatGrid.currentMeasurePosition(
+            currentTime: vm.currentTime,
+            beatTimes: clip.beatTimes,
+            anchor: clip.firstDownbeatSeconds,
+            beatsPerMeasure: clip.beatsPerMeasure
+        )
+        return VStack(spacing: 14) {
+            HStack {
+                BPMBadge(
+                    bpm: clip.bpm,
+                    isAnalyzing: vm.isAnalyzingBeats,
+                    measurePosition: measurePosition,
+                    beatsPerMeasure: clip.beatsPerMeasure,
+                    onDetect: { Task { await detectBeats() } }
+                )
+                Spacer()
+            }
+            if clip.hasBeatAnalysis {
+                DownbeatAnchorBar(
+                    hasAnchor: clip.firstDownbeatSeconds != nil,
+                    onTap: tapOnBeatOne,
+                    onClear: clearDownbeat
+                )
+            }
             Scrubber(
                 currentTime: vm.currentTime,
                 duration: vm.duration,
                 loopStart: vm.loopStart,
                 loopEnd: vm.loopEnd,
+                beatTimes: clip.beatTimes,
+                downbeatIndices: downbeats,
                 onSeek: vm.seek(to:)
             )
             HStack {
@@ -256,6 +304,8 @@ private struct Scrubber: View {
     let duration: Double
     let loopStart: Double?
     let loopEnd: Double?
+    let beatTimes: [Double]
+    let downbeatIndices: Set<Int>
     let onSeek: (Double) -> Void
 
     @GestureState private var dragProgress: Double?
@@ -268,6 +318,7 @@ private struct Scrubber: View {
                 Capsule()
                     .fill(Theme.Color.surfaceElevated)
                     .frame(height: 6)
+                beatTicksOverlay(width: width)
                 loopRegionOverlay(width: width)
                 Capsule()
                     .fill(Theme.Color.accent)
@@ -293,6 +344,24 @@ private struct Scrubber: View {
             )
         }
         .frame(height: 32)
+    }
+
+    @ViewBuilder
+    private func beatTicksOverlay(width: CGFloat) -> some View {
+        if duration > 0, !beatTimes.isEmpty {
+            ZStack(alignment: .leading) {
+                ForEach(Array(beatTimes.enumerated()), id: \.offset) { index, time in
+                    let isDownbeat = downbeatIndices.contains(index)
+                    Rectangle()
+                        .fill(isDownbeat ? Theme.Color.accent : Theme.Color.textTertiary.opacity(0.6))
+                        .frame(
+                            width: isDownbeat ? 2 : 1,
+                            height: isDownbeat ? 14 : 8
+                        )
+                        .offset(x: width * (time / duration))
+                }
+            }
+        }
     }
 
     @ViewBuilder

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -383,37 +383,6 @@ private struct Scrubber: View {
     }
 }
 
-// MARK: - Speed pills
-
-struct SpeedPills: View {
-    static let speeds: [Double] = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5]
-    let selected: Double
-    let onSelect: (Double) -> Void
-
-    var body: some View {
-        HStack(spacing: 6) {
-            ForEach(Self.speeds, id: \.self) { speed in
-                let isSelected = SpeedFormatter.equals(selected, speed)
-                let tint = Theme.Color.speedPillColor(for: speed)
-                Button {
-                    onSelect(speed)
-                } label: {
-                    Text(SpeedFormatter.pill(speed))
-                        .font(.system(.footnote, design: .rounded, weight: .semibold))
-                        .foregroundStyle(isSelected ? .black : tint)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 6)
-                        .background(
-                            Capsule()
-                                .fill(isSelected ? tint : Theme.Color.surfaceElevated)
-                        )
-                }
-                .buttonStyle(.plain)
-            }
-        }
-    }
-}
-
 // MARK: - Frame step
 
 private struct FrameStepButton: View {
@@ -583,29 +552,3 @@ private struct SaveMarkerSheet: View {
     }
 }
 
-// MARK: - Formatting
-
-enum SpeedFormatter {
-    static func pill(_ speed: Double) -> String {
-        let base: String
-        if speed == speed.rounded() {
-            base = "\(Int(speed))"
-        } else {
-            base = String(format: "%g", speed)
-        }
-        return "\(base)×"
-    }
-
-    static func timestamp(_ seconds: Double) -> String {
-        guard seconds.isFinite, seconds >= 0 else { return "--:--" }
-        let totalCentis = Int((seconds * 100).rounded())
-        let mins = totalCentis / 6000
-        let secs = (totalCentis / 100) % 60
-        let cent = totalCentis % 100
-        return String(format: "%d:%02d.%02d", mins, secs, cent)
-    }
-
-    static func equals(_ a: Double, _ b: Double) -> Bool {
-        abs(a - b) < 0.001
-    }
-}

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -551,4 +551,3 @@ private struct SaveMarkerSheet: View {
         .preferredColorScheme(.dark)
     }
 }
-

--- a/StepBackTests/BeatGridTests.swift
+++ b/StepBackTests/BeatGridTests.swift
@@ -1,0 +1,136 @@
+@testable import StepBack
+import XCTest
+
+final class BeatGridTests: XCTestCase {
+
+    private let beats = [0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0]
+
+    // MARK: - nearestBeatIndex
+
+    func testNearestBeatOnEmptyReturnsNil() {
+        XCTAssertNil(BeatGrid.nearestBeatIndex(to: 1.0, in: []))
+    }
+
+    func testNearestBeatExactHit() {
+        XCTAssertEqual(BeatGrid.nearestBeatIndex(to: 2.0, in: beats), 3)
+    }
+
+    func testNearestBeatBetweenPrefersCloser() {
+        // 1.7 is 0.2 past 1.5, 0.3 before 2.0 → nearest is 1.5 (index 2)
+        XCTAssertEqual(BeatGrid.nearestBeatIndex(to: 1.7, in: beats), 2)
+        // 1.8 is 0.3 past 1.5, 0.2 before 2.0 → nearest is 2.0 (index 3)
+        XCTAssertEqual(BeatGrid.nearestBeatIndex(to: 1.8, in: beats), 3)
+    }
+
+    func testNearestBeatBeforeFirstAndAfterLast() {
+        XCTAssertEqual(BeatGrid.nearestBeatIndex(to: 0.0, in: beats), 0)
+        XCTAssertEqual(BeatGrid.nearestBeatIndex(to: 99.0, in: beats), beats.count - 1)
+    }
+
+    // MARK: - offsetMs
+
+    func testOffsetMsEarly() {
+        // Tap at 1.45, nearest is 1.5 → -50ms (early)
+        XCTAssertEqual(BeatGrid.offsetMs(from: 1.45, toNearestBeatIn: beats) ?? 0, -50, accuracy: 1e-6)
+    }
+
+    func testOffsetMsLate() {
+        // Tap at 1.55, nearest is 1.5 → +50ms (late)
+        XCTAssertEqual(BeatGrid.offsetMs(from: 1.55, toNearestBeatIn: beats) ?? 0, 50, accuracy: 1e-6)
+    }
+
+    // MARK: - downbeatIndices
+
+    func testDownbeatIndicesRequiresAnchor() {
+        XCTAssertTrue(
+            BeatGrid.downbeatIndices(beatTimes: beats, anchor: nil, beatsPerMeasure: 4).isEmpty
+        )
+    }
+
+    func testDownbeatIndicesEveryNthBeat() {
+        // Anchor at 1.0 (index 1). With beatsPerMeasure = 4, downbeats at
+        // indices {1, 5} (wrap backwards would hit -3, out of range).
+        let indices = BeatGrid.downbeatIndices(
+            beatTimes: beats, anchor: 1.0, beatsPerMeasure: 4
+        )
+        XCTAssertEqual(indices, [1, 5])
+    }
+
+    func testDownbeatIndicesIncludesBackwardsFromAnchor() {
+        // Anchor at 2.5 (index 4). With bpm = 2, downbeats at {0, 2, 4, 6}.
+        let indices = BeatGrid.downbeatIndices(
+            beatTimes: beats, anchor: 2.5, beatsPerMeasure: 2
+        )
+        XCTAssertEqual(indices, [0, 2, 4, 6])
+    }
+
+    // MARK: - currentMeasurePosition
+
+    func testMeasurePositionIsOneAtAnchor() {
+        let position = BeatGrid.currentMeasurePosition(
+            currentTime: 1.0, beatTimes: beats, anchor: 1.0, beatsPerMeasure: 4
+        )
+        XCTAssertEqual(position, 1)
+    }
+
+    func testMeasurePositionAdvancesAcrossBeats() {
+        // Anchor at 1.0 (index 1). currentTime 1.5 (index 2) → position 2.
+        XCTAssertEqual(
+            BeatGrid.currentMeasurePosition(
+                currentTime: 1.5, beatTimes: beats, anchor: 1.0, beatsPerMeasure: 4
+            ),
+            2
+        )
+        XCTAssertEqual(
+            BeatGrid.currentMeasurePosition(
+                currentTime: 2.0, beatTimes: beats, anchor: 1.0, beatsPerMeasure: 4
+            ),
+            3
+        )
+        XCTAssertEqual(
+            BeatGrid.currentMeasurePosition(
+                currentTime: 2.5, beatTimes: beats, anchor: 1.0, beatsPerMeasure: 4
+            ),
+            4
+        )
+        // Back to 1 on the next measure.
+        XCTAssertEqual(
+            BeatGrid.currentMeasurePosition(
+                currentTime: 3.0, beatTimes: beats, anchor: 1.0, beatsPerMeasure: 4
+            ),
+            1
+        )
+    }
+
+    func testMeasurePositionBeforeAnchorWrapsCleanly() {
+        // Anchor at 2.5 (index 4). currentTime 1.0 (index 1) → -3 mod 4 = 1 → position 2.
+        XCTAssertEqual(
+            BeatGrid.currentMeasurePosition(
+                currentTime: 1.0, beatTimes: beats, anchor: 2.5, beatsPerMeasure: 4
+            ),
+            2
+        )
+    }
+
+    // MARK: - rescale
+
+    func testRescaleDoubleInsertsMidpoints() {
+        let input = [0.0, 0.5, 1.0]
+        XCTAssertEqual(BeatGrid.rescale(beatTimes: input, factor: 2), [0, 0.25, 0.5, 0.75, 1.0])
+    }
+
+    func testRescaleHalveKeepsEveryOther() {
+        let input = [0.0, 0.25, 0.5, 0.75, 1.0]
+        XCTAssertEqual(BeatGrid.rescale(beatTimes: input, factor: 0.5), [0, 0.5, 1.0])
+    }
+
+    func testRescaleIdentityForOtherFactors() {
+        let input = [0.0, 0.5, 1.0]
+        XCTAssertEqual(BeatGrid.rescale(beatTimes: input, factor: 3), input)
+    }
+
+    func testRescaleShortInputUnchanged() {
+        XCTAssertEqual(BeatGrid.rescale(beatTimes: [], factor: 2), [])
+        XCTAssertEqual(BeatGrid.rescale(beatTimes: [1.0], factor: 2), [1.0])
+    }
+}


### PR DESCRIPTION
## Summary

Surfaces the beat detector from #11 in the practice screen.

- \`BeatGrid\` pure helpers (nearestBeatIndex, offsetMs, downbeatIndices, currentMeasurePosition, rescale) with comprehensive unit tests including the tricky anchor-after-currentTime wrap
- \`PracticePlayerViewModel.detectBeats\` runs \`BeatDetector\` against the current \`playerItem.asset\`, writes \`bpm\` + \`beatTimesData\`, yields to a save callback (view stays the SwiftData owner)
- \`tapOnBeatOne\` / \`clearDownbeatAnchor\` wrap \`firstDownbeatSeconds\` updates
- \`BPMBadge\` shows "Detect beats" pill → spinner → BPM + live MeasureCounter
- \`MeasureCounter\` highlights the current beat (1..4 for WCS)
- \`DownbeatAnchorBar\` is a prominent "Tap on beat 1" button until set, then becomes a confirm + reset pair
- \`Scrubber\` overlays thin grey ticks for every beat and tall pink ticks for downbeats, behind the loop region

Beat UI code lives in \`PracticeBeatUI.swift\` so \`PracticeView.swift\` stays well under SwiftLint's file-length warning.

## Test plan

- [x] \`BeatGridTests\` covers nearest-beat binary search, signed offset ms, downbeat indices with forward+backward walking, measure wrap, and rescale
- [ ] CI green
- [ ] On device, with real music:
  - [ ] "Detect beats" button analyzes in ~1-2s per minute
  - [ ] BPM badge shows a plausible number
  - [ ] Scrubber has visible beat ticks spaced evenly
  - [ ] Tap "on beat 1" while playing — the measure counter locks onto \`1\` for that beat and cycles 2/3/4/1 naturally
  - [ ] Downbeat anchor survives a relaunch
  - [ ] Re-opening after detection instantly shows the cached result (no re-analysis)

Closes #12