### PR TITLE
×2 / ÷2 BPM rescale (#13)

### DIFF
--- a/StepBack/Services/PracticePlayerViewModel.swift
+++ b/StepBack/Services/PracticePlayerViewModel.swift
@@ -163,6 +163,23 @@ final class PracticePlayerViewModel: ObservableObject {
         onSave()
     }
 
+    /// Rescales the cached beat grid by `factor` (2 or 0.5), updates the BPM,
+    /// and snaps any existing downbeat anchor to the nearest beat on the new
+    /// grid so the measure counter doesn't drift.
+    func rescaleBeats(for clip: DanceClip, factor: Double, onSave: @escaping () -> Void) {
+        guard clip.hasBeatAnalysis, factor > 0 else { return }
+        let rescaled = BeatGrid.rescale(beatTimes: clip.beatTimes, factor: factor)
+        clip.setBeatTimes(rescaled)
+        if let bpm = clip.bpm {
+            clip.bpm = bpm * factor
+        }
+        if let anchor = clip.firstDownbeatSeconds,
+           let snapped = BeatGrid.nearestBeatIndex(to: anchor, in: rescaled) {
+            clip.firstDownbeatSeconds = rescaled[snapped]
+        }
+        onSave()
+    }
+
     // MARK: - A/B loop
 
     var hasLoopRegion: Bool {

--- a/StepBack/Views/PracticeBeatUI.swift
+++ b/StepBack/Views/PracticeBeatUI.swift
@@ -8,6 +8,7 @@ struct BPMBadge: View {
     let measurePosition: Int?
     let beatsPerMeasure: Int
     let onDetect: () -> Void
+    var onRescale: ((Double) -> Void)?
 
     var body: some View {
         HStack(spacing: 8) {
@@ -15,6 +16,10 @@ struct BPMBadge: View {
                 Text("\(Int(bpm.rounded())) BPM")
                     .font(.system(.footnote, design: .rounded, weight: .bold))
                     .foregroundStyle(Theme.Color.accent)
+                if let onRescale {
+                    RescaleButton(label: "÷2") { onRescale(0.5) }
+                    RescaleButton(label: "×2") { onRescale(2) }
+                }
                 if let measurePosition {
                     MeasureCounter(current: measurePosition, total: beatsPerMeasure)
                 }
@@ -36,6 +41,24 @@ struct BPMBadge: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
         .background(Theme.Color.accentSoft, in: Capsule())
+    }
+}
+
+// MARK: - Rescale button
+
+private struct RescaleButton: View {
+    let label: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(label)
+                .font(.system(.caption2, design: .rounded, weight: .bold))
+                .foregroundStyle(Theme.Color.textPrimary)
+                .frame(width: 24, height: 20)
+                .background(Theme.Color.surfaceElevated, in: RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
     }
 }
 

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -109,6 +109,12 @@ struct PracticeView: View {
         }
     }
 
+    private func rescaleBeats(by factor: Double) {
+        vm.rescaleBeats(for: clip, factor: factor) {
+            try? modelContext.save()
+        }
+    }
+
     @ViewBuilder
     private var content: some View {
         if let error = vm.loadError {
@@ -164,7 +170,8 @@ struct PracticeView: View {
                     isAnalyzing: vm.isAnalyzingBeats,
                     measurePosition: measurePosition,
                     beatsPerMeasure: clip.beatsPerMeasure,
-                    onDetect: { Task { await detectBeats() } }
+                    onDetect: { Task { await detectBeats() } },
+                    onRescale: clip.hasBeatAnalysis ? rescaleBeats : nil
                 )
                 Spacer()
             }


### PR DESCRIPTION
## Summary

Escape hatch for songs where the detector locks onto half-time or double-time (common for swing and blues).

- \`PracticePlayerViewModel.rescaleBeats(for:factor:onSave:)\` rescales the cached beat grid via \`BeatGrid.rescale\`, updates \`clip.bpm\` by the same factor, and snaps any existing \`firstDownbeatSeconds\` anchor to the nearest beat on the new grid so the measure counter doesn't drift
- \`BPMBadge\` grows an optional \`onRescale\` callback; two small tappable pills appear next to the BPM value when analysis exists
- Rescale ignores factors other than 2 and 0.5 — \`BeatGrid.rescale\` already returns the input unchanged in that case

## Test plan

- [x] \`BeatGridTests.rescale*\` (added in #12) covers both factors and degenerate inputs
- [ ] CI green
- [ ] On device:
  - [ ] Detect beats on a swing clip; if the counter feels half-speed, tap ×2 — BPM doubles, ticks densify, measure counter speeds up
  - [ ] Tap ÷2 → ticks halve
  - [ ] Downbeat anchor persists through a rescale (beat 1 stays on beat 1)
  - [ ] Rescale persists across app relaunch

Closes #13