### PR TITLE
Step-timing mode: tap, histogram, offset (#14)

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -12,8 +12,10 @@
 		1EC09265A1CD5B1E67415B39 /* StepBackApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023608F63978F9D1668F5AFC /* StepBackApp.swift */; };
 		1F02ADF6471B01E48A824A49 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6745FF48B10D28A5ED4BB568 /* Models.swift */; };
 		2B90619AE0B5262B774DEAC1 /* PracticeControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35987D9825155E131A40950 /* PracticeControls.swift */; };
+		4181110140BD581DBFB0A380 /* StepTimingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3B8C1BB7ACE2D1C13C7200 /* StepTimingTests.swift */; };
 		527B9B596B00D2C774173ECA /* PracticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35AE6C8D6564306E1B0ADA20 /* PracticeView.swift */; };
 		5F405BD1B2F2EB7F30970683 /* LibraryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */; };
+		622A6663058E88A57B465B62 /* StepTiming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0265ABC8E91AF4657EB95F83 /* StepTiming.swift */; };
 		691A3AE86C110C252A1412FE /* BeatGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078CB839E392E788201DD665 /* BeatGrid.swift */; };
 		76D520F6EC5A0A8E57C8AAA1 /* BeatDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6BC077A9FA8B51D07C178A0 /* BeatDetectorTests.swift */; };
 		7FA3BBA0113FDF3282819E84 /* PracticePlayerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */; };
@@ -45,6 +47,7 @@
 
 /* Begin PBXFileReference section */
 		023608F63978F9D1668F5AFC /* StepBackApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepBackApp.swift; sourceTree = "<group>"; };
+		0265ABC8E91AF4657EB95F83 /* StepTiming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepTiming.swift; sourceTree = "<group>"; };
 		078CB839E392E788201DD665 /* BeatGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeatGrid.swift; sourceTree = "<group>"; };
 		0C54B956DF5DE01C00D95680 /* AutoTagServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoTagServiceTests.swift; sourceTree = "<group>"; };
 		16E676751B59ED083837CE39 /* SpeedFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedFormatterTests.swift; sourceTree = "<group>"; };
@@ -70,6 +73,7 @@
 		C59BD8F65AE46261EEFD4F69 /* BeatDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeatDetector.swift; sourceTree = "<group>"; };
 		CC6BAE20433D2ED45F00AD41 /* PracticeBeatUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeBeatUI.swift; sourceTree = "<group>"; };
 		D8F8476EAB523378C1F1E046 /* PhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosService.swift; sourceTree = "<group>"; };
+		DB3B8C1BB7ACE2D1C13C7200 /* StepTimingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepTimingTests.swift; sourceTree = "<group>"; };
 		F6BC077A9FA8B51D07C178A0 /* BeatDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeatDetectorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -114,6 +118,7 @@
 				848D52E156E709AA0226CEE8 /* ModelsTests.swift */,
 				B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */,
 				16E676751B59ED083837CE39 /* SpeedFormatterTests.swift */,
+				DB3B8C1BB7ACE2D1C13C7200 /* StepTimingTests.swift */,
 				B7C112AEA59633E85CF8267D /* ThemeTests.swift */,
 			);
 			path = StepBackTests;
@@ -127,6 +132,7 @@
 				078CB839E392E788201DD665 /* BeatGrid.swift */,
 				D8F8476EAB523378C1F1E046 /* PhotosService.swift */,
 				543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */,
+				0265ABC8E91AF4657EB95F83 /* StepTiming.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -272,6 +278,7 @@
 				527B9B596B00D2C774173ECA /* PracticeView.swift in Sources */,
 				9F90D5641396A9BF3E7A09FE /* RootView.swift in Sources */,
 				1EC09265A1CD5B1E67415B39 /* StepBackApp.swift in Sources */,
+				622A6663058E88A57B465B62 /* StepTiming.swift in Sources */,
 				A49A15759EECD46EC5E3A694 /* Theme.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -288,6 +295,7 @@
 				C376AB20647940A9E53A89D0 /* ModelsTests.swift in Sources */,
 				CC6F98E7716925F88449689A /* PhotosServiceTests.swift in Sources */,
 				F35848C14CA3DF06A4EBE554 /* SpeedFormatterTests.swift in Sources */,
+				4181110140BD581DBFB0A380 /* StepTimingTests.swift in Sources */,
 				C97E59DA25A51E16ECA03607 /* ThemeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/StepBack/Services/PracticePlayerViewModel.swift
+++ b/StepBack/Services/PracticePlayerViewModel.swift
@@ -20,6 +20,9 @@ final class PracticePlayerViewModel: ObservableObject {
     @Published private(set) var isAnalyzingBeats: Bool = false
     @Published var analysisError: String?
 
+    @Published var stepTimingActive: Bool = false
+    @Published private(set) var stepTaps: [StepTap] = []
+
     let player: AVPlayer
 
     // `timeObserver` is written once in init and read once in deinit — both
@@ -161,6 +164,28 @@ final class PracticePlayerViewModel: ObservableObject {
     func clearDownbeatAnchor(for clip: DanceClip, onSave: @escaping () -> Void) {
         clip.firstDownbeatSeconds = nil
         onSave()
+    }
+
+    // MARK: - Step timing
+
+    func toggleStepTiming() {
+        stepTimingActive.toggle()
+        if !stepTimingActive {
+            stepTaps.removeAll()
+        }
+    }
+
+    func recordStepTap(against beatTimes: [Double]) {
+        guard stepTimingActive, !beatTimes.isEmpty else { return }
+        guard let offset = BeatGrid.offsetMs(
+            from: currentTime,
+            toNearestBeatIn: beatTimes
+        ) else { return }
+        stepTaps.append(StepTap(time: currentTime, offsetMs: offset))
+    }
+
+    func clearStepTaps() {
+        stepTaps.removeAll()
     }
 
     /// Rescales the cached beat grid by `factor` (2 or 0.5), updates the BPM,

--- a/StepBack/Services/StepTiming.swift
+++ b/StepBack/Services/StepTiming.swift
@@ -47,6 +47,14 @@ enum StepRating: Equatable {
     }
 }
 
+struct BucketCounts: Equatable {
+    var perfect: Int = 0
+    var good: Int = 0
+    var off: Int = 0
+
+    var total: Int { perfect + good + off }
+}
+
 enum StepTimingStats {
     /// Arithmetic mean of the offsets in milliseconds. Negative = average
     /// tap is early; positive = average tap is late.
@@ -57,17 +65,15 @@ enum StepTimingStats {
     }
 
     /// Per-bucket count for quick glance stats.
-    static func bucketCounts(_ taps: [StepTap]) -> (perfect: Int, good: Int, off: Int) {
-        var perfect = 0
-        var good = 0
-        var off = 0
+    static func bucketCounts(_ taps: [StepTap]) -> BucketCounts {
+        var counts = BucketCounts()
         for tap in taps {
             switch StepRating(offsetMs: tap.offsetMs) {
-            case .perfect: perfect += 1
-            case .good: good += 1
-            case .off: off += 1
+            case .perfect: counts.perfect += 1
+            case .good: counts.good += 1
+            case .off: counts.off += 1
             }
         }
-        return (perfect, good, off)
+        return counts
     }
 }

--- a/StepBack/Services/StepTiming.swift
+++ b/StepBack/Services/StepTiming.swift
@@ -1,0 +1,73 @@
+import Foundation
+import SwiftUI
+
+struct StepTap: Identifiable, Equatable {
+    let id = UUID()
+    let time: Double
+    let offsetMs: Double
+
+    init(id: UUID = UUID(), time: Double, offsetMs: Double) {
+        self.time = time
+        self.offsetMs = offsetMs
+    }
+}
+
+enum StepRating: Equatable {
+    case perfect
+    case good
+    case off
+
+    /// Buckets by absolute offset from the nearest beat:
+    /// `<50ms` perfect, `<120ms` good, otherwise off.
+    init(offsetMs: Double) {
+        let magnitude = abs(offsetMs)
+        if magnitude < 50 {
+            self = .perfect
+        } else if magnitude < 120 {
+            self = .good
+        } else {
+            self = .off
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .perfect: Color(hex: 0x5FFFA8)
+        case .good: Color(hex: 0xFFD93B)
+        case .off: Color(hex: 0xFF5F5F)
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .perfect: "Perfect"
+        case .good: "Good"
+        case .off: "Off"
+        }
+    }
+}
+
+enum StepTimingStats {
+    /// Arithmetic mean of the offsets in milliseconds. Negative = average
+    /// tap is early; positive = average tap is late.
+    static func averageOffsetMs(_ taps: [StepTap]) -> Double? {
+        guard !taps.isEmpty else { return nil }
+        let total = taps.reduce(0.0) { $0 + $1.offsetMs }
+        return total / Double(taps.count)
+    }
+
+    /// Per-bucket count for quick glance stats.
+    static func bucketCounts(_ taps: [StepTap]) -> (perfect: Int, good: Int, off: Int) {
+        var perfect = 0
+        var good = 0
+        var off = 0
+        for tap in taps {
+            switch StepRating(offsetMs: tap.offsetMs) {
+            case .perfect: perfect += 1
+            case .good: good += 1
+            case .off: off += 1
+            }
+        }
+        return (perfect, good, off)
+    }
+}

--- a/StepBack/Views/PracticeBeatUI.swift
+++ b/StepBack/Views/PracticeBeatUI.swift
@@ -85,6 +85,132 @@ struct MeasureCounter: View {
     }
 }
 
+// MARK: - Step timing panel
+
+struct StepTimingPanel: View {
+    let taps: [StepTap]
+    let isActive: Bool
+    let onToggle: () -> Void
+    let onTap: () -> Void
+    let onReset: () -> Void
+
+    var body: some View {
+        VStack(spacing: 10) {
+            HStack {
+                Label("Step timing", systemImage: "metronome")
+                    .font(.system(.footnote, design: .rounded, weight: .semibold))
+                    .foregroundStyle(isActive ? Theme.Color.accent : Theme.Color.textSecondary)
+                Spacer()
+                Button(isActive ? "Stop" : "Start", action: onToggle)
+                    .font(Theme.Font.caption)
+                    .foregroundStyle(Theme.Color.accent)
+            }
+            if isActive {
+                tapButton
+                StepHistogram(taps: taps)
+                    .frame(height: 44)
+                summary
+            }
+        }
+        .padding(12)
+        .background(Theme.Color.surface, in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var tapButton: some View {
+        Button(action: onTap) {
+            Text("Tap")
+                .font(.system(.title, design: .rounded, weight: .heavy))
+                .foregroundStyle(.black)
+                .frame(maxWidth: .infinity)
+                .frame(height: 56)
+                .background(Theme.Color.accent, in: RoundedRectangle(cornerRadius: 10))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var summary: some View {
+        let average = StepTimingStats.averageOffsetMs(taps)
+        let counts = StepTimingStats.bucketCounts(taps)
+        return HStack(spacing: 14) {
+            if let average {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Avg offset")
+                        .font(Theme.Font.caption)
+                        .foregroundStyle(Theme.Color.textTertiary)
+                    Text(averageText(average))
+                        .font(Theme.Font.timestamp)
+                        .foregroundStyle(Theme.Color.textPrimary)
+                }
+            } else {
+                Text("Tap along with the beat")
+                    .font(Theme.Font.caption)
+                    .foregroundStyle(Theme.Color.textTertiary)
+            }
+            Spacer()
+            if !taps.isEmpty {
+                BucketBadge(color: StepRating.perfect.color, count: counts.perfect)
+                BucketBadge(color: StepRating.good.color, count: counts.good)
+                BucketBadge(color: StepRating.off.color, count: counts.off)
+                Button("Reset", action: onReset)
+                    .font(Theme.Font.caption)
+                    .foregroundStyle(Theme.Color.textTertiary)
+            }
+        }
+    }
+
+    private func averageText(_ value: Double) -> String {
+        let sign = value > 0 ? "+" : ""
+        let descriptor = value > 0 ? "late" : value < 0 ? "early" : "on beat"
+        return "\(sign)\(Int(value.rounded())) ms (\(descriptor))"
+    }
+}
+
+private struct StepHistogram: View {
+    let taps: [StepTap]
+
+    var body: some View {
+        GeometryReader { geo in
+            if taps.isEmpty {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Theme.Color.surfaceElevated)
+            } else {
+                let count = taps.count
+                let spacing: CGFloat = 2
+                let availableWidth = max(0, geo.size.width - CGFloat(count - 1) * spacing)
+                let barWidth = max(1, availableWidth / CGFloat(count))
+                HStack(alignment: .center, spacing: spacing) {
+                    ForEach(taps) { tap in
+                        RoundedRectangle(cornerRadius: 1.5)
+                            .fill(StepRating(offsetMs: tap.offsetMs).color)
+                            .frame(width: barWidth, height: barHeight(for: tap.offsetMs, in: geo.size.height))
+                            .offset(y: tap.offsetMs > 0 ? (geo.size.height - barHeight(for: tap.offsetMs, in: geo.size.height)) / 2 : -(geo.size.height - barHeight(for: tap.offsetMs, in: geo.size.height)) / 2)
+                    }
+                }
+            }
+        }
+    }
+
+    private func barHeight(for offsetMs: Double, in total: CGFloat) -> CGFloat {
+        let magnitude = min(200.0, abs(offsetMs))
+        let ratio = magnitude / 200.0
+        return max(6, total * CGFloat(ratio))
+    }
+}
+
+private struct BucketBadge: View {
+    let color: Color
+    let count: Int
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Circle().fill(color).frame(width: 8, height: 8)
+            Text("\(count)")
+                .font(Theme.Font.timestamp)
+                .foregroundStyle(Theme.Color.textSecondary)
+        }
+    }
+}
+
 // MARK: - Downbeat anchor controls
 
 struct DownbeatAnchorBar: View {

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -73,7 +73,6 @@ struct PracticeView: View {
         }
     }
 
-
     @ViewBuilder
     private var content: some View {
         if let error = vm.loadError {

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -181,6 +181,13 @@ struct PracticeView: View {
                     onTap: tapOnBeatOne,
                     onClear: clearDownbeat
                 )
+                StepTimingPanel(
+                    taps: vm.stepTaps,
+                    isActive: vm.stepTimingActive,
+                    onToggle: vm.toggleStepTiming,
+                    onTap: { vm.recordStepTap(against: clip.beatTimes) },
+                    onReset: vm.clearStepTaps
+                )
             }
             Scrubber(
                 currentTime: vm.currentTime,

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -73,47 +73,6 @@ struct PracticeView: View {
         }
     }
 
-    private func saveMarker(label: String, speed: Double) {
-        guard let start = vm.loopStart, let end = vm.loopEnd, end > start else { return }
-        let marker = LoopMarker(
-            label: label,
-            startSeconds: start,
-            endSeconds: end,
-            preferredSpeed: speed,
-            clip: clip
-        )
-        modelContext.insert(marker)
-        try? modelContext.save()
-    }
-
-    private func deleteMarker(_ marker: LoopMarker) {
-        modelContext.delete(marker)
-        try? modelContext.save()
-    }
-
-    private func detectBeats() async {
-        await vm.detectBeats(for: clip) {
-            try? modelContext.save()
-        }
-    }
-
-    private func tapOnBeatOne() {
-        vm.tapOnBeatOne(for: clip) {
-            try? modelContext.save()
-        }
-    }
-
-    private func clearDownbeat() {
-        vm.clearDownbeatAnchor(for: clip) {
-            try? modelContext.save()
-        }
-    }
-
-    private func rescaleBeats(by factor: Double) {
-        vm.rescaleBeats(for: clip, factor: factor) {
-            try? modelContext.save()
-        }
-    }
 
     @ViewBuilder
     private var content: some View {
@@ -279,6 +238,52 @@ struct PracticeView: View {
                 .buttonStyle(.plain)
                 .accessibilityLabel("Clear loop")
             }
+        }
+    }
+}
+
+// MARK: - Persistence + command helpers
+
+extension PracticeView {
+    fileprivate func saveMarker(label: String, speed: Double) {
+        guard let start = vm.loopStart, let end = vm.loopEnd, end > start else { return }
+        let marker = LoopMarker(
+            label: label,
+            startSeconds: start,
+            endSeconds: end,
+            preferredSpeed: speed,
+            clip: clip
+        )
+        modelContext.insert(marker)
+        try? modelContext.save()
+    }
+
+    fileprivate func deleteMarker(_ marker: LoopMarker) {
+        modelContext.delete(marker)
+        try? modelContext.save()
+    }
+
+    fileprivate func detectBeats() async {
+        await vm.detectBeats(for: clip) {
+            try? modelContext.save()
+        }
+    }
+
+    fileprivate func tapOnBeatOne() {
+        vm.tapOnBeatOne(for: clip) {
+            try? modelContext.save()
+        }
+    }
+
+    fileprivate func clearDownbeat() {
+        vm.clearDownbeatAnchor(for: clip) {
+            try? modelContext.save()
+        }
+    }
+
+    fileprivate func rescaleBeats(by factor: Double) {
+        vm.rescaleBeats(for: clip, factor: factor) {
+            try? modelContext.save()
         }
     }
 }

--- a/StepBackTests/StepTimingTests.swift
+++ b/StepBackTests/StepTimingTests.swift
@@ -1,0 +1,56 @@
+@testable import StepBack
+import XCTest
+
+final class StepTimingTests: XCTestCase {
+
+    // MARK: - StepRating
+
+    func testRatingBucketsByAbsoluteOffset() {
+        XCTAssertEqual(StepRating(offsetMs: 0), .perfect)
+        XCTAssertEqual(StepRating(offsetMs: 49.9), .perfect)
+        XCTAssertEqual(StepRating(offsetMs: -49.9), .perfect)
+        XCTAssertEqual(StepRating(offsetMs: 50), .good)
+        XCTAssertEqual(StepRating(offsetMs: -119.9), .good)
+        XCTAssertEqual(StepRating(offsetMs: 120), .off)
+        XCTAssertEqual(StepRating(offsetMs: -500), .off)
+    }
+
+    // MARK: - StepTimingStats
+
+    func testAverageNilOnEmpty() {
+        XCTAssertNil(StepTimingStats.averageOffsetMs([]))
+    }
+
+    func testAverageIsArithmeticMean() {
+        let taps = [
+            StepTap(time: 1, offsetMs: -40),
+            StepTap(time: 2, offsetMs: 60),
+            StepTap(time: 3, offsetMs: -20)
+        ]
+        XCTAssertEqual(StepTimingStats.averageOffsetMs(taps) ?? 0, 0, accuracy: 1e-6)
+    }
+
+    func testAverageNegativeForEarlyBias() {
+        let taps = [
+            StepTap(time: 1, offsetMs: -80),
+            StepTap(time: 2, offsetMs: -40)
+        ]
+        XCTAssertEqual(StepTimingStats.averageOffsetMs(taps) ?? 0, -60, accuracy: 1e-6)
+    }
+
+    func testBucketCountsDistributesEveryTap() {
+        let taps = [
+            StepTap(time: 1, offsetMs: 10),     // perfect
+            StepTap(time: 2, offsetMs: -45),    // perfect
+            StepTap(time: 3, offsetMs: 80),     // good
+            StepTap(time: 4, offsetMs: -115),   // good
+            StepTap(time: 5, offsetMs: 150),    // off
+            StepTap(time: 6, offsetMs: -999)    // off
+        ]
+        let counts = StepTimingStats.bucketCounts(taps)
+        XCTAssertEqual(counts.perfect, 2)
+        XCTAssertEqual(counts.good, 2)
+        XCTAssertEqual(counts.off, 2)
+        XCTAssertEqual(counts.perfect + counts.good + counts.off, taps.count)
+    }
+}

--- a/StepBackTests/StepTimingTests.swift
+++ b/StepBackTests/StepTimingTests.swift
@@ -51,6 +51,6 @@ final class StepTimingTests: XCTestCase {
         XCTAssertEqual(counts.perfect, 2)
         XCTAssertEqual(counts.good, 2)
         XCTAssertEqual(counts.off, 2)
-        XCTAssertEqual(counts.perfect + counts.good + counts.off, taps.count)
+        XCTAssertEqual(counts.total, taps.count)
     }
 }


### PR DESCRIPTION
## Summary

Completes v1.5. Dance along with the video, tap every step, see how early or late you were.

- \`StepTap\`, \`StepRating\`, \`StepTimingStats\` live in a new pure-Swift file so the whole analysis path is testable without touching the view model
- Bucket boundaries: <50ms perfect, <120ms good, otherwise off
- \`PracticePlayerViewModel\` grows \`stepTimingActive\` + \`stepTaps\`; tap is only recorded while active; leaving the mode clears taps so the next session starts clean
- \`StepTimingPanel\` shows a Start/Stop toggle, full-width Tap button, signed-offset histogram (late bars go up, early bars go down, colors by rating), and a summary line with average offset and per-bucket counts + reset

## Test plan

- [x] \`StepTimingTests\`: bucket boundaries, arithmetic mean (including early-biased), full-distribution counting
- [ ] CI green
- [ ] On device (the real test):
  - [ ] Enable step timing, play the clip, tap every step for a basic 8-count
  - [ ] Histogram shows a spread; perfect taps cluster in the middle
  - [ ] Average offset matches subjective feel (positive = late)
  - [ ] Reset clears without stopping the mode
  - [ ] Stop empties the session

Closes #14