### PR TITLE
Fix video import crash, missing asset identifier, and silent playback

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -462,11 +462,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = "StepBack/Generated-Info.plist";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "StepBack needs access to your videos so you can practice with them.";
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -487,11 +482,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = "StepBack/Generated-Info.plist";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "StepBack needs access to your videos so you can practice with them.";
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/StepBack/Generated-Info.plist
+++ b/StepBack/Generated-Info.plist
@@ -20,6 +20,14 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>StepBack needs access to your videos so you can practice with them.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>StepBack saves ghost-overlay recordings back to your Photos library.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>StepBack uses the camera to record ghost-overlay practice clips.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>StepBack records audio alongside ghost-overlay practice clips.</string>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UIColorName</key>

--- a/StepBack/StepBackApp.swift
+++ b/StepBack/StepBackApp.swift
@@ -7,8 +7,12 @@ struct StepBackApp: App {
     init() {
         // Route playback through .playback so video audio ignores the silent
         // switch — otherwise the phone's ringer toggle mutes practice clips.
-        try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .moviePlayback)
-        try? AVAudioSession.sharedInstance().setActive(true)
+        // Dispatched off-actor: setActive does IPC that trips the runtime's
+        // unsafeForcedSync diagnostic when invoked from App.init on MainActor.
+        DispatchQueue.global(qos: .userInitiated).async {
+            try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .moviePlayback)
+            try? AVAudioSession.sharedInstance().setActive(true)
+        }
     }
 
     var body: some Scene {

--- a/StepBack/StepBackApp.swift
+++ b/StepBack/StepBackApp.swift
@@ -1,8 +1,16 @@
+import AVFoundation
 import SwiftData
 import SwiftUI
 
 @main
 struct StepBackApp: App {
+    init() {
+        // Route playback through .playback so video audio ignores the silent
+        // switch — otherwise the phone's ringer toggle mutes practice clips.
+        try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .moviePlayback)
+        try? AVAudioSession.sharedInstance().setActive(true)
+    }
+
     var body: some Scene {
         WindowGroup {
             RootView()

--- a/StepBack/Views/LibraryView.swift
+++ b/StepBack/Views/LibraryView.swift
@@ -44,6 +44,9 @@ struct LibraryView: View {
                     pickerItems = []
                     Task { await importClips(items) }
                 }
+                .task {
+                    _ = await photosService.requestAuthorization()
+                }
         }
     }
 
@@ -131,7 +134,8 @@ struct LibraryView: View {
             selection: $pickerItems,
             maxSelectionCount: 50,
             matching: .videos,
-            preferredItemEncoding: .current
+            preferredItemEncoding: .current,
+            photoLibrary: .shared()
         ) {
             Label("Import", systemImage: "plus")
                 .labelStyle(.iconOnly)

--- a/project.yml
+++ b/project.yml
@@ -31,6 +31,10 @@ targets:
       path: StepBack/Generated-Info.plist
       properties:
         CFBundleDisplayName: StepBack
+        NSPhotoLibraryUsageDescription: "StepBack needs access to your videos so you can practice with them."
+        NSPhotoLibraryAddUsageDescription: "StepBack saves ghost-overlay recordings back to your Photos library."
+        NSCameraUsageDescription: "StepBack uses the camera to record ghost-overlay practice clips."
+        NSMicrophoneUsageDescription: "StepBack records audio alongside ghost-overlay practice clips."
         UILaunchScreen:
           UIColorName: LaunchBackground
         UISupportedInterfaceOrientations:
@@ -46,11 +50,9 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.stepback.app
         TARGETED_DEVICE_FAMILY: "1,2"
-        INFOPLIST_KEY_NSPhotoLibraryUsageDescription: "StepBack needs access to your videos so you can practice with them."
-        INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
-        INFOPLIST_KEY_UILaunchScreen_Generation: YES
-        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
-        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        CODE_SIGN_STYLE: Automatic
+        CURRENT_PROJECT_VERSION: 1
+        MARKETING_VERSION: "0.1.0"
         CODE_SIGN_STYLE: Automatic
         CURRENT_PROJECT_VERSION: 1
         MARKETING_VERSION: "0.1.0"


### PR DESCRIPTION
## Summary

Three fixes that make on-device import and playback work:

- **Photos usage descriptions missing from built Info.plist.** They were declared as `INFOPLIST_KEY_*` build settings, which Xcode only merges when it auto-generates the plist. This target ships a real `StepBack/Generated-Info.plist`, so those settings were silently dropped and iOS hard-crashed on first Photos access. Moved the keys into `info.properties` in `project.yml` (and regenerated the pbxproj).
- **`PhotosPickerItem.itemIdentifier` was always nil.** Two causes: (1) authorization was requested *after* the picker returned, too late; and (2) SwiftUI's `PhotosPicker` runs in a sandboxed mode unless you pass `photoLibrary: .shared()`, in which case no identifier comes back even with full authorization. Request auth on `LibraryView.task` and pass `.shared()` to the picker.
- **Clip audio was silent when the ringer switch was off.** No `AVAudioSession` was configured, so iOS defaulted to `.soloAmbient`, which respects the silent switch. Set `.playback` with `.moviePlayback` mode at app launch. The `setActive` call is dispatched off MainActor because it trips the new `unsafeForcedSync` runtime diagnostic when invoked from `App.init`.

## Test plan

- [ ] Fresh install on device (delete the previous build first so iOS picks up the new Info.plist)
- [ ] Launch app, verify the Photos permission prompt appears on first LibraryView show
- [ ] Tap Import, open the picker, pick a video, verify it imports and appears in the grid
- [ ] Tap the imported clip, verify video plays with audio even when the ringer silent switch is on
- [ ] No `unsafeForcedSync` warning in the Xcode console at launch
