### PR TITLE
Add pinch-to-zoom on the practice player

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		B6CB4CFDF1EB16757B0D78AA /* CompareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D24FDCCE45AEFB352C5EBF /* CompareView.swift */; };
 		BE33E08127A1601493FB7837 /* LoopEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57317F752B65258CB2D04530 /* LoopEvaluatorTests.swift */; };
 		C376AB20647940A9E53A89D0 /* ModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848D52E156E709AA0226CEE8 /* ModelsTests.swift */; };
+		C7DD824378246BBC211824D8 /* ZoomablePlayerContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC399CE513ADED3ED5394848 /* ZoomablePlayerContainer.swift */; };
 		C97E59DA25A51E16ECA03607 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C112AEA59633E85CF8267D /* ThemeTests.swift */; };
 		CC6F98E7716925F88449689A /* PhotosServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */; };
 		D9873262DD68100D8D3C1021 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 462E264B215595E9EC3D1C4A /* Assets.xcassets */; };
@@ -67,6 +68,7 @@
 		99CA1B5B91B8D4637FEEF872 /* AutoTagService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoTagService.swift; sourceTree = "<group>"; };
 		A3776C829FB11907CC7E87F9 /* StepBack.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = StepBack.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AAB30650146433E889DC2AF4 /* LibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryView.swift; sourceTree = "<group>"; };
+		AC399CE513ADED3ED5394848 /* ZoomablePlayerContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomablePlayerContainer.swift; sourceTree = "<group>"; };
 		B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosServiceTests.swift; sourceTree = "<group>"; };
 		B7C112AEA59633E85CF8267D /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		C35987D9825155E131A40950 /* PracticeControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeControls.swift; sourceTree = "<group>"; };
@@ -103,6 +105,7 @@
 				C35987D9825155E131A40950 /* PracticeControls.swift */,
 				35AE6C8D6564306E1B0ADA20 /* PracticeView.swift */,
 				56E94F050959741028A8574D /* RootView.swift */,
+				AC399CE513ADED3ED5394848 /* ZoomablePlayerContainer.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -280,6 +283,7 @@
 				1EC09265A1CD5B1E67415B39 /* StepBackApp.swift in Sources */,
 				622A6663058E88A57B465B62 /* StepTiming.swift in Sources */,
 				A49A15759EECD46EC5E3A694 /* Theme.swift in Sources */,
+				C7DD824378246BBC211824D8 /* ZoomablePlayerContainer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -82,10 +82,12 @@ struct PracticeView: View {
                 .tint(Theme.Color.accent)
         } else {
             VStack(spacing: 0) {
-                PlayerSurface(player: vm.player)
-                    .scaleEffect(x: vm.mirrored ? -1 : 1, y: 1)
-                    .aspectRatio(16.0 / 9.0, contentMode: .fit)
-                    .background(Color.black)
+                ZoomablePlayerContainer {
+                    PlayerSurface(player: vm.player)
+                        .scaleEffect(x: vm.mirrored ? -1 : 1, y: 1)
+                }
+                .aspectRatio(16.0 / 9.0, contentMode: .fit)
+                .background(Color.black)
                 controls
             }
         }

--- a/StepBack/Views/ZoomablePlayerContainer.swift
+++ b/StepBack/Views/ZoomablePlayerContainer.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+/// Wraps video content with pinch-to-zoom, drag-to-pan (when zoomed), and
+/// double-tap to toggle between 1x and 2x. Clips the content so zoomed pixels
+/// don't overflow into surrounding controls.
+///
+/// Zooming anchors at the center of the frame. This is a deliberate
+/// simplification — pinch-around-centroid felt fiddlier than useful during
+/// playback, and users can just pan after zooming.
+struct ZoomablePlayerContainer<Content: View>: View {
+
+    private let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    @State private var scale: CGFloat = 1.0
+    @State private var baseScale: CGFloat = 1.0
+    @State private var offset: CGSize = .zero
+    @State private var baseOffset: CGSize = .zero
+
+    private let minScale: CGFloat = 1.0
+    private let maxScale: CGFloat = 5.0
+    private let doubleTapZoom: CGFloat = 2.0
+
+    var body: some View {
+        GeometryReader { proxy in
+            content
+                .frame(width: proxy.size.width, height: proxy.size.height)
+                .scaleEffect(scale, anchor: .center)
+                .offset(offset)
+                .frame(width: proxy.size.width, height: proxy.size.height)
+                .contentShape(Rectangle())
+                .gesture(
+                    SimultaneousGesture(magnifyGesture(in: proxy.size), panGesture(in: proxy.size))
+                )
+                .onTapGesture(count: 2) {
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                        if scale > minScale + 0.001 {
+                            scale = minScale
+                            offset = .zero
+                        } else {
+                            scale = doubleTapZoom
+                            offset = .zero
+                        }
+                        baseScale = scale
+                        baseOffset = offset
+                    }
+                }
+        }
+        .clipped()
+    }
+
+    // MARK: - Gestures
+
+    private func magnifyGesture(in size: CGSize) -> some Gesture {
+        MagnifyGesture()
+            .onChanged { value in
+                let proposed = baseScale * value.magnification
+                scale = min(max(proposed, minScale), maxScale)
+                offset = clampedOffset(baseOffset, for: scale, in: size)
+            }
+            .onEnded { _ in
+                baseScale = scale
+                // Snap back to 1x if the user pinched essentially closed.
+                if scale <= minScale + 0.01 {
+                    withAnimation(.spring(response: 0.25, dampingFraction: 0.85)) {
+                        scale = minScale
+                        baseScale = minScale
+                        offset = .zero
+                        baseOffset = .zero
+                    }
+                }
+                baseOffset = offset
+            }
+    }
+
+    private func panGesture(in size: CGSize) -> some Gesture {
+        DragGesture(minimumDistance: 1)
+            .onChanged { value in
+                guard scale > minScale + 0.01 else { return }
+                let proposed = CGSize(
+                    width: baseOffset.width + value.translation.width,
+                    height: baseOffset.height + value.translation.height
+                )
+                offset = clampedOffset(proposed, for: scale, in: size)
+            }
+            .onEnded { _ in
+                baseOffset = offset
+            }
+    }
+
+    /// Keeps the zoomed content from panning off past its own edges. With
+    /// `scale` = s and frame size W×H, the zoomed content occupies s·W × s·H,
+    /// so the maximum offset in each axis is half the overflow.
+    private func clampedOffset(_ proposed: CGSize, for scale: CGFloat, in size: CGSize) -> CGSize {
+        let extraW = max(0, (size.width * scale - size.width) / 2)
+        let extraH = max(0, (size.height * scale - size.height) / 2)
+        return CGSize(
+            width: min(max(proposed.width, -extraW), extraW),
+            height: min(max(proposed.height, -extraH), extraH)
+        )
+    }
+}

--- a/StepBack/Views/ZoomablePlayerContainer.swift
+++ b/StepBack/Views/ZoomablePlayerContainer.swift
@@ -26,28 +26,40 @@ struct ZoomablePlayerContainer<Content: View>: View {
 
     var body: some View {
         GeometryReader { proxy in
-            content
-                .frame(width: proxy.size.width, height: proxy.size.height)
-                .scaleEffect(scale, anchor: .center)
-                .offset(offset)
-                .frame(width: proxy.size.width, height: proxy.size.height)
-                .contentShape(Rectangle())
-                .gesture(
-                    SimultaneousGesture(magnifyGesture(in: proxy.size), panGesture(in: proxy.size))
-                )
-                .onTapGesture(count: 2) {
-                    withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
-                        if scale > minScale + 0.001 {
-                            scale = minScale
-                            offset = .zero
-                        } else {
-                            scale = doubleTapZoom
-                            offset = .zero
+            ZStack {
+                // The video itself. allowsHitTesting(false) lets UIKit's
+                // default touch-swallowing step out of the way so SwiftUI
+                // gestures on the overlay actually fire.
+                content
+                    .frame(width: proxy.size.width, height: proxy.size.height)
+                    .scaleEffect(scale, anchor: .center)
+                    .offset(offset)
+                    .allowsHitTesting(false)
+
+                // Transparent gesture surface sitting on top of the video.
+                Color.clear
+                    .contentShape(Rectangle())
+                    .gesture(
+                        SimultaneousGesture(
+                            magnifyGesture(in: proxy.size),
+                            panGesture(in: proxy.size)
+                        )
+                    )
+                    .onTapGesture(count: 2) {
+                        withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                            if scale > minScale + 0.001 {
+                                scale = minScale
+                                offset = .zero
+                            } else {
+                                scale = doubleTapZoom
+                                offset = .zero
+                            }
+                            baseScale = scale
+                            baseOffset = offset
                         }
-                        baseScale = scale
-                        baseOffset = offset
                     }
-                }
+            }
+            .frame(width: proxy.size.width, height: proxy.size.height)
         }
         .clipped()
     }


### PR DESCRIPTION
## Summary

Pinch-to-zoom on the practice player.

- New `ZoomablePlayerContainer` wraps the `PlayerSurface`: **pinch** to zoom between 1x and 5x, **drag to pan** when zoomed, **double-tap** to toggle between 1x and 2x, and a pinch-closed snap-back to 1x.
- Zoom anchors at center (a deliberate simplification — anchoring around the pinch centroid fought with panning; center-zoom + pan-after felt cleaner during playback).
- The container is `.clipped()` so zoomed pixels don't bleed into the scrubber/controls below.
- Composes with mirror mode: both are `scaleEffect`s, so flipping horizontally still works while zoomed.
- Playback, loop, frame stepping, beat UI, and all other controls are untouched — the zoom is purely a view-layer transform on the displayed pixels.

Branched from `main`, so it can merge independently of the open edit/group PR (#36) and the already-landed import fix (#35).

## Test plan

- [ ] Play a clip, pinch in with two fingers → video scales up smoothly, playback keeps going.
- [ ] When zoomed past 1x, drag with one finger → video pans; released, it stays where you left it.
- [ ] Try to drag past the edge of the zoomed content → offset clamps, you can't pan off into black bars.
- [ ] Pinch closed to below 1x → snaps back to 1x centered with a spring.
- [ ] Double-tap when at 1x → jumps to 2x centered. Double-tap again → back to 1x.
- [ ] Toggle mirror while zoomed → flips horizontally, zoom level is preserved.
- [ ] Use the scrubber, speed pills, frame-step buttons, loop A/B — none are affected by the zoom transform.
