### PR TITLE
Add clip edit + bulk move/delete with groups (rebased on main)

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		03C973FD27336E9DD2EDE507 /* PracticeBeatUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6BAE20433D2ED45F00AD41 /* PracticeBeatUI.swift */; };
 		1724638BD2B70699A591FE9B /* AutoTagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CA1B5B91B8D4637FEEF872 /* AutoTagService.swift */; };
+		1D0BE1897582A939153E6CE8 /* ClipEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D25E6771271EDD5B867F61E /* ClipEditView.swift */; };
 		1EC09265A1CD5B1E67415B39 /* StepBackApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023608F63978F9D1668F5AFC /* StepBackApp.swift */; };
 		1F02ADF6471B01E48A824A49 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6745FF48B10D28A5ED4BB568 /* Models.swift */; };
 		2B90619AE0B5262B774DEAC1 /* PracticeControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35987D9825155E131A40950 /* PracticeControls.swift */; };
@@ -62,6 +63,7 @@
 		7093A077C0A2C139BD7BDD29 /* BeatGridTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeatGridTests.swift; sourceTree = "<group>"; };
 		848D52E156E709AA0226CEE8 /* ModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsTests.swift; sourceTree = "<group>"; };
 		8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryFormatterTests.swift; sourceTree = "<group>"; };
+		8D25E6771271EDD5B867F61E /* ClipEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipEditView.swift; sourceTree = "<group>"; };
 		90115F7F368CDD3B0832B3B3 /* Generated-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Generated-Info.plist"; sourceTree = "<group>"; };
 		92D24FDCCE45AEFB352C5EBF /* CompareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompareView.swift; sourceTree = "<group>"; };
 		99CA1B5B91B8D4637FEEF872 /* AutoTagService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoTagService.swift; sourceTree = "<group>"; };
@@ -97,6 +99,7 @@
 		2BAE89F5B3212B0E382D6904 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				8D25E6771271EDD5B867F61E /* ClipEditView.swift */,
 				92D24FDCCE45AEFB352C5EBF /* CompareView.swift */,
 				AAB30650146433E889DC2AF4 /* LibraryView.swift */,
 				CC6BAE20433D2ED45F00AD41 /* PracticeBeatUI.swift */,
@@ -268,6 +271,7 @@
 				1724638BD2B70699A591FE9B /* AutoTagService.swift in Sources */,
 				E9E06DF791FF47015B3DDFA8 /* BeatDetector.swift in Sources */,
 				691A3AE86C110C252A1412FE /* BeatGrid.swift in Sources */,
+				1D0BE1897582A939153E6CE8 /* ClipEditView.swift in Sources */,
 				B6CB4CFDF1EB16757B0D78AA /* CompareView.swift in Sources */,
 				A88000A1ACD9503F7A9D6143 /* LibraryView.swift in Sources */,
 				1F02ADF6471B01E48A824A49 /* Models.swift in Sources */,

--- a/StepBack/Utilities/Theme.swift
+++ b/StepBack/Utilities/Theme.swift
@@ -55,4 +55,12 @@ extension Color {
         let blue = Double(hex & 0xFF) / 255
         self.init(.sRGB, red: red, green: green, blue: blue, opacity: alpha)
     }
+
+    /// Parses a `"#RRGGBB"` or `"RRGGBB"` string into a Color. Falls back to
+    /// the theme accent if the string isn't a valid hex triplet.
+    init(tagHex: String) {
+        let stripped: Substring = tagHex.hasPrefix("#") ? tagHex.dropFirst() : Substring(tagHex)
+        let value = UInt32(stripped, radix: 16) ?? 0xFF3B7F
+        self.init(hex: value)
+    }
 }

--- a/StepBack/Views/ClipEditView.swift
+++ b/StepBack/Views/ClipEditView.swift
@@ -1,0 +1,225 @@
+import SwiftData
+import SwiftUI
+
+/// Edit a single clip: title, notes, and group (tag) membership. Also lets
+/// the user create a new group inline and assign it.
+struct ClipEditView: View {
+
+    @Bindable var clip: DanceClip
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \Tag.name) private var allTags: [Tag]
+
+    @State private var newGroupName: String = ""
+    @FocusState private var newGroupFocused: Bool
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Title") {
+                    TextField("Clip title", text: $clip.title)
+                        .textInputAutocapitalization(.words)
+                }
+
+                Section("Notes") {
+                    TextField("What is this clip about?", text: $clip.notes, axis: .vertical)
+                        .lineLimit(3...8)
+                }
+
+                Section("Groups") {
+                    if allTags.isEmpty {
+                        Text("No groups yet. Create one below.")
+                            .font(Theme.Font.caption)
+                            .foregroundStyle(Theme.Color.textTertiary)
+                    } else {
+                        ForEach(allTags) { tag in
+                            groupRow(for: tag)
+                        }
+                    }
+
+                    HStack {
+                        TextField("New group name", text: $newGroupName)
+                            .focused($newGroupFocused)
+                            .submitLabel(.done)
+                            .onSubmit(addGroup)
+                        Button("Add", action: addGroup)
+                            .buttonStyle(.borderless)
+                            .foregroundStyle(Theme.Color.accent)
+                            .disabled(trimmedGroupName.isEmpty)
+                    }
+                }
+            }
+            .scrollContentBackground(.hidden)
+            .background(Theme.Color.background)
+            .navigationTitle("Edit clip")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel", role: .cancel) { dismiss() }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") {
+                        try? modelContext.save()
+                        dismiss()
+                    }
+                    .fontWeight(.semibold)
+                }
+            }
+        }
+    }
+
+    // MARK: - Rows
+
+    @ViewBuilder
+    private func groupRow(for tag: Tag) -> some View {
+        let isSelected = clip.tags.contains(where: { $0.id == tag.id })
+        Button {
+            toggle(tag)
+        } label: {
+            HStack(spacing: 10) {
+                Circle()
+                    .fill(Color(tagHex: tag.colorHex))
+                    .frame(width: 10, height: 10)
+                Text(tag.name)
+                    .foregroundStyle(Theme.Color.textPrimary)
+                Spacer()
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(Theme.Color.accent)
+                        .fontWeight(.semibold)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Actions
+
+    private var trimmedGroupName: String {
+        newGroupName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func toggle(_ tag: Tag) {
+        if let index = clip.tags.firstIndex(where: { $0.id == tag.id }) {
+            clip.tags.remove(at: index)
+        } else {
+            clip.tags.append(tag)
+        }
+    }
+
+    private func addGroup() {
+        let name = trimmedGroupName
+        guard !name.isEmpty else { return }
+
+        if let existing = allTags.first(where: { $0.name.caseInsensitiveCompare(name) == .orderedSame }) {
+            if !clip.tags.contains(where: { $0.id == existing.id }) {
+                clip.tags.append(existing)
+            }
+        } else {
+            let tag = Tag(name: name, colorHex: "#FF3B7F")
+            modelContext.insert(tag)
+            clip.tags.append(tag)
+        }
+        newGroupName = ""
+        newGroupFocused = false
+    }
+}
+
+/// Sheet for moving multiple clips into one group at once.
+struct BulkMoveToGroupView: View {
+
+    let clips: [DanceClip]
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \Tag.name) private var allTags: [Tag]
+
+    @State private var newGroupName: String = ""
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Text("Moving \(clips.count) clip\(clips.count == 1 ? "" : "s") into a group.")
+                        .font(Theme.Font.caption)
+                        .foregroundStyle(Theme.Color.textSecondary)
+                }
+                Section("Pick a group") {
+                    ForEach(allTags) { tag in
+                        Button {
+                            assignAll(to: tag)
+                        } label: {
+                            HStack(spacing: 10) {
+                                Circle()
+                                    .fill(Color(tagHex: tag.colorHex))
+                                    .frame(width: 10, height: 10)
+                                Text(tag.name)
+                                    .foregroundStyle(Theme.Color.textPrimary)
+                                Spacer()
+                                Image(systemName: "chevron.right")
+                                    .foregroundStyle(Theme.Color.textTertiary)
+                            }
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                Section("Or create a new group") {
+                    HStack {
+                        TextField("Group name", text: $newGroupName)
+                            .submitLabel(.done)
+                            .onSubmit(createAndAssign)
+                        Button("Create", action: createAndAssign)
+                            .buttonStyle(.borderless)
+                            .foregroundStyle(Theme.Color.accent)
+                            .disabled(newGroupName.trimmingCharacters(in: .whitespaces).isEmpty)
+                    }
+                }
+            }
+            .scrollContentBackground(.hidden)
+            .background(Theme.Color.background)
+            .navigationTitle("Move to group")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Cancel", role: .cancel) { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func assignAll(to tag: Tag) {
+        for clip in clips where !clip.tags.contains(where: { $0.id == tag.id }) {
+            clip.tags.append(tag)
+        }
+        try? modelContext.save()
+        dismiss()
+    }
+
+    private func createAndAssign() {
+        let name = newGroupName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { return }
+        let tag: Tag
+        if let existing = allTags.first(where: { $0.name.caseInsensitiveCompare(name) == .orderedSame }) {
+            tag = existing
+        } else {
+            tag = Tag(name: name, colorHex: "#FF3B7F")
+            modelContext.insert(tag)
+        }
+        assignAll(to: tag)
+    }
+}
+
+#Preview {
+    let container = try! ModelContainer(
+        for: DanceClip.self, Tag.self, LoopMarker.self,
+        configurations: .init(isStoredInMemoryOnly: true)
+    )
+    let clip = DanceClip(title: "Sample", assetIdentifier: "preview")
+    container.mainContext.insert(clip)
+    return ClipEditView(clip: clip)
+        .modelContainer(container)
+        .preferredColorScheme(.dark)
+}

--- a/StepBack/Views/LibraryView.swift
+++ b/StepBack/Views/LibraryView.swift
@@ -15,6 +15,12 @@ struct LibraryView: View {
     @State private var importError: String?
     @State private var selectedTagIDs: Set<UUID> = []
 
+    @State private var editingClip: DanceClip?
+    @State private var isSelecting: Bool = false
+    @State private var selectedClipIDs: Set<UUID> = []
+    @State private var bulkMovePresented: Bool = false
+    @State private var deleteConfirmation: DeleteConfirmation?
+
     private let columns = [GridItem(.adaptive(minimum: 140), spacing: 12)]
     private let photosService: PhotosServicing = PhotosService()
 
@@ -47,7 +53,33 @@ struct LibraryView: View {
                 .task {
                     _ = await photosService.requestAuthorization()
                 }
+                .sheet(item: $editingClip) { clip in
+                    ClipEditView(clip: clip)
+                        .preferredColorScheme(.dark)
+                }
+                .sheet(isPresented: $bulkMovePresented) {
+                    BulkMoveToGroupView(clips: clipsMatching(selectedClipIDs))
+                        .preferredColorScheme(.dark)
+                        .onDisappear { exitSelectionMode() }
+                }
+                .confirmationDialog(
+                    deleteConfirmation?.title ?? "",
+                    isPresented: .init(
+                        get: { deleteConfirmation != nil },
+                        set: { if !$0 { deleteConfirmation = nil } }
+                    ),
+                    presenting: deleteConfirmation
+                ) { target in
+                    Button("Delete", role: .destructive) { commitDelete(target) }
+                    Button("Cancel", role: .cancel) { deleteConfirmation = nil }
+                } message: { target in
+                    Text(target.message)
+                }
         }
+    }
+
+    private func clipsMatching(_ ids: Set<UUID>) -> [DanceClip] {
+        clips.filter { ids.contains($0.id) }
     }
 
     // MARK: - Content
@@ -77,18 +109,77 @@ struct LibraryView: View {
                 ScrollView {
                     LazyVGrid(columns: columns, spacing: 12) {
                         ForEach(filteredClips) { clip in
-                            NavigationLink {
-                                PracticeView(clip: clip)
-                            } label: {
-                                LibraryCell(clip: clip)
-                            }
-                            .buttonStyle(.plain)
+                            clipCell(for: clip)
                         }
                     }
                     .padding(12)
                 }
+                if isSelecting {
+                    bulkActionBar
+                }
             }
         }
+    }
+
+    @ViewBuilder
+    private func clipCell(for clip: DanceClip) -> some View {
+        let isSelected = selectedClipIDs.contains(clip.id)
+        if isSelecting {
+            Button {
+                toggleSelection(clip)
+            } label: {
+                LibraryCell(
+                    clip: clip,
+                    selectionState: isSelected ? .selected : .unselected,
+                    onEdit: nil,
+                    onDelete: nil
+                )
+            }
+            .buttonStyle(.plain)
+        } else {
+            NavigationLink {
+                PracticeView(clip: clip)
+            } label: {
+                LibraryCell(
+                    clip: clip,
+                    selectionState: .hidden,
+                    onEdit: { editingClip = clip },
+                    onDelete: { deleteConfirmation = .single(clip) }
+                )
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private var bulkActionBar: some View {
+        HStack(spacing: 12) {
+            Text("\(selectedClipIDs.count) selected")
+                .font(Theme.Font.bodyEmphasized)
+                .foregroundStyle(Theme.Color.textPrimary)
+            Spacer()
+            Button {
+                bulkMovePresented = true
+            } label: {
+                Label("Move", systemImage: "folder")
+                    .font(Theme.Font.bodyEmphasized)
+                    .foregroundStyle(Theme.Color.accent)
+            }
+            .disabled(selectedClipIDs.isEmpty)
+            Button(role: .destructive) {
+                deleteConfirmation = .bulk(clipsMatching(selectedClipIDs))
+            } label: {
+                Label("Delete", systemImage: "trash")
+                    .font(Theme.Font.bodyEmphasized)
+                    .foregroundStyle(.red)
+            }
+            .disabled(selectedClipIDs.isEmpty)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(
+            Theme.Color.surfaceElevated
+                .overlay(Rectangle().frame(height: 1).foregroundStyle(Theme.Color.divider), alignment: .top)
+        )
     }
 
     private var emptyState: some View {
@@ -111,10 +202,20 @@ struct LibraryView: View {
     @ToolbarContentBuilder
     private var toolbar: some ToolbarContent {
         ToolbarItem(placement: .topBarTrailing) {
-            if clips.isEmpty {
-                EmptyView()
-            } else {
-                importButton
+            if isSelecting {
+                Button("Done") { exitSelectionMode() }
+                    .fontWeight(.semibold)
+                    .foregroundStyle(Theme.Color.accent)
+            } else if !clips.isEmpty {
+                HStack(spacing: 10) {
+                    Button {
+                        enterSelectionMode()
+                    } label: {
+                        Text("Select")
+                            .foregroundStyle(Theme.Color.textPrimary)
+                    }
+                    importButton
+                }
             }
         }
         ToolbarItem(placement: .topBarLeading) {
@@ -126,6 +227,24 @@ struct LibraryView: View {
                         .foregroundStyle(Theme.Color.textSecondary)
                 }
             }
+        }
+    }
+
+    private func enterSelectionMode() {
+        isSelecting = true
+        selectedClipIDs = []
+    }
+
+    private func exitSelectionMode() {
+        isSelecting = false
+        selectedClipIDs = []
+    }
+
+    private func toggleSelection(_ clip: DanceClip) {
+        if selectedClipIDs.contains(clip.id) {
+            selectedClipIDs.remove(clip.id)
+        } else {
+            selectedClipIDs.insert(clip.id)
         }
     }
 
@@ -251,21 +370,61 @@ struct LibraryView: View {
         }
         return "Clip \(identifier.prefix(6))"
     }
+
+    // MARK: - Delete
+
+    private func commitDelete(_ target: DeleteConfirmation) {
+        switch target {
+        case .single(let clip):
+            modelContext.delete(clip)
+        case .bulk(let clips):
+            for clip in clips {
+                modelContext.delete(clip)
+            }
+            exitSelectionMode()
+        }
+        try? modelContext.save()
+        deleteConfirmation = nil
+    }
 }
 
 // MARK: - Cell
 
+enum CellSelectionState {
+    case hidden
+    case selected
+    case unselected
+}
+
 private struct LibraryCell: View {
     let clip: DanceClip
+    var selectionState: CellSelectionState = .hidden
+    var onEdit: (() -> Void)?
+    var onDelete: (() -> Void)?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             ZStack {
                 Theme.Color.surfaceElevated
                 thumbnail
+                if selectionState == .selected {
+                    Theme.Color.accent.opacity(0.25)
+                }
                 VStack {
+                    HStack {
+                        if selectionState != .hidden {
+                            selectionIndicator
+                        }
+                        Spacer()
+                        if selectionState == .hidden, onEdit != nil || onDelete != nil {
+                            menuButton
+                        }
+                    }
                     Spacer()
                     HStack {
+                        if !clip.tags.isEmpty {
+                            tagChips
+                        }
                         Spacer()
                         durationBadge
                     }
@@ -274,6 +433,10 @@ private struct LibraryCell: View {
             }
             .frame(height: 180)
             .clipShape(RoundedRectangle(cornerRadius: Theme.Metrics.cornerRadius))
+            .overlay(
+                RoundedRectangle(cornerRadius: Theme.Metrics.cornerRadius)
+                    .stroke(Theme.Color.accent, lineWidth: selectionState == .selected ? 2 : 0)
+            )
 
             Text(clip.title)
                 .font(Theme.Font.bodyEmphasized)
@@ -307,6 +470,52 @@ private struct LibraryCell: View {
             .padding(.vertical, 2)
             .background(Color.black.opacity(0.55), in: Capsule())
     }
+
+    private var selectionIndicator: some View {
+        Image(systemName: selectionState == .selected ? "checkmark.circle.fill" : "circle")
+            .font(.system(size: 22))
+            .foregroundStyle(selectionState == .selected ? Theme.Color.accent : Color.white.opacity(0.85))
+            .shadow(color: .black.opacity(0.4), radius: 2, x: 0, y: 1)
+    }
+
+    private var menuButton: some View {
+        Menu {
+            if let onEdit {
+                Button {
+                    onEdit()
+                } label: {
+                    Label("Edit", systemImage: "pencil")
+                }
+            }
+            if let onDelete {
+                Button(role: .destructive) {
+                    onDelete()
+                } label: {
+                    Label("Delete", systemImage: "trash")
+                }
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 15, weight: .bold))
+                .foregroundStyle(Color.white)
+                .frame(width: 28, height: 28)
+                .background(Color.black.opacity(0.55), in: Circle())
+        }
+        .menuStyle(.borderlessButton)
+    }
+
+    private var tagChips: some View {
+        HStack(spacing: 3) {
+            ForEach(clip.tags.prefix(3)) { tag in
+                Circle()
+                    .fill(Color(tagHex: tag.colorHex))
+                    .frame(width: 6, height: 6)
+            }
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(Color.black.opacity(0.55), in: Capsule())
+    }
 }
 
 // MARK: - Tag filter bar
@@ -321,7 +530,7 @@ private struct TagFilterBar: View {
             HStack(spacing: 8) {
                 ForEach(tags) { tag in
                     let isSelected = selected.contains(tag.id)
-                    let accent = Color(hex: UInt32(tag.colorHex.stripHex, radix: 16) ?? 0xFF3B7F)
+                    let accent = Color(tagHex: tag.colorHex)
                     Button {
                         if isSelected {
                             selected.remove(tag.id)
@@ -356,14 +565,6 @@ private struct TagFilterBar: View {
     }
 }
 
-private extension String {
-    /// Strips a leading `#` and returns the hex remainder suitable for
-    /// `Int(_:radix:)` parsing.
-    var stripHex: Substring {
-        hasPrefix("#") ? dropFirst() : Substring(self)
-    }
-}
-
 // MARK: - Formatting
 
 enum LibraryFormatter {
@@ -393,6 +594,29 @@ enum LibraryError: Error, LocalizedError {
         switch self {
         case .missingAssetIdentifier: "The selected item has no asset identifier."
         }
+    }
+}
+
+enum DeleteConfirmation: Identifiable {
+    case single(DanceClip)
+    case bulk([DanceClip])
+
+    var id: String {
+        switch self {
+        case .single(let clip): "single-\(clip.id)"
+        case .bulk(let clips): "bulk-" + clips.map(\.id.uuidString).joined(separator: ",")
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .single: "Delete this clip?"
+        case .bulk(let clips): "Delete \(clips.count) clip\(clips.count == 1 ? "" : "s")?"
+        }
+    }
+
+    var message: String {
+        "The video itself stays in Photos — only StepBack's reference to it is removed."
     }
 }
 

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -13,6 +13,7 @@ struct PracticeView: View {
     @State private var markerSheetPresented = false
     @State private var comparePickerPresented = false
     @State private var compareSecondary: DanceClip?
+    @State private var editSheetPresented = false
 
     init(clip: DanceClip) {
         self.clip = clip
@@ -33,6 +34,13 @@ struct PracticeView: View {
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 HStack(spacing: 8) {
+                    Button {
+                        editSheetPresented = true
+                    } label: {
+                        Image(systemName: "pencil")
+                            .foregroundStyle(Theme.Color.textPrimary)
+                    }
+                    .accessibilityLabel("Edit clip")
                     Button {
                         comparePickerPresented = true
                     } label: {
@@ -70,6 +78,10 @@ struct PracticeView: View {
                 saveMarker(label: label, speed: speed)
             }
             .presentationDetents([.medium])
+        }
+        .sheet(isPresented: $editSheetPresented) {
+            ClipEditView(clip: clip)
+                .preferredColorScheme(.dark)
         }
     }
 


### PR DESCRIPTION
## Summary

Re-opened from #36 (closed when its base branch was deleted after #35 merged). Same commit, cherry-picked onto current main.

- Per-clip edit sheet (`ClipEditView`) for title, notes, group/tag membership, and inline group creation.
- Library cell ellipsis menu (Edit / Delete) and tag color chips.
- Selection mode with bulk Move and Delete.
- Pencil button on the practice screen opens the same edit sheet.
- Tag color parsing consolidated into `Color(tagHex:)`.

## Test plan

- [ ] Tap a clip's ••• → Edit → change title → updates everywhere.
- [ ] In edit sheet, type new group name, tap Add → checked + chip appears.
- [ ] Toggle a group off → chip disappears.
- [ ] Tap Select → tap multiple clips → Move → pick group → confirm.
- [ ] Selection mode → Delete → confirm → clips disappear; Photos untouched.
- [ ] Pencil on practice screen opens the same sheet.
