### PR TITLE
Split clips into named patterns with bounded-loop playback

### DIFF
--- a/StepBack/Models/Models.swift
+++ b/StepBack/Models/Models.swift
@@ -21,6 +21,9 @@ final class DanceClip: Equatable, Hashable {
     @Relationship(deleteRule: .cascade, inverse: \LoopMarker.clip)
     var loopMarkers: [LoopMarker] = []
 
+    @Relationship(deleteRule: .cascade, inverse: \ClipSegment.clip)
+    var segments: [ClipSegment] = []
+
     var tags: [Tag] = []
 
     init(
@@ -116,5 +119,52 @@ final class LoopMarker {
 
     var durationSeconds: Double {
         max(0, endSeconds - startSeconds)
+    }
+}
+
+@Model
+final class ClipSegment: Equatable, Hashable {
+    var id: UUID
+    var title: String
+    var startSeconds: Double
+    var endSeconds: Double
+    var preferredSpeed: Double
+    var notes: String
+    var dateAdded: Date
+    var orderIndex: Int
+    var clip: DanceClip?
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        startSeconds: Double,
+        endSeconds: Double,
+        preferredSpeed: Double = 1.0,
+        notes: String = "",
+        dateAdded: Date = Date(),
+        orderIndex: Int = 0,
+        clip: DanceClip? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.startSeconds = startSeconds
+        self.endSeconds = endSeconds
+        self.preferredSpeed = preferredSpeed
+        self.notes = notes
+        self.dateAdded = dateAdded
+        self.orderIndex = orderIndex
+        self.clip = clip
+    }
+
+    var durationSeconds: Double {
+        max(0, endSeconds - startSeconds)
+    }
+
+    static func == (lhs: ClipSegment, rhs: ClipSegment) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
     }
 }

--- a/StepBack/Services/PracticePlayerViewModel.swift
+++ b/StepBack/Services/PracticePlayerViewModel.swift
@@ -217,6 +217,7 @@ final class PracticePlayerViewModel: ObservableObject {
         if let end = loopEnd, end <= currentTime {
             loopEnd = nil
         }
+        activeSegmentID = nil
     }
 
     func markLoopEnd() {
@@ -225,11 +226,13 @@ final class PracticePlayerViewModel: ObservableObject {
             return
         }
         loopEnd = currentTime
+        activeSegmentID = nil
     }
 
     func clearLoop() {
         loopStart = nil
         loopEnd = nil
+        activeSegmentID = nil
     }
 
     func applyMarker(_ marker: LoopMarker) {
@@ -237,6 +240,27 @@ final class PracticePlayerViewModel: ObservableObject {
         loopEnd = marker.endSeconds
         setSpeed(marker.preferredSpeed)
         seek(to: marker.startSeconds)
+    }
+
+    // MARK: - Segments
+
+    @Published private(set) var activeSegmentID: UUID?
+
+    /// Plays a segment by clamping the loop region to its bounds and starting
+    /// playback at its start. Reuses the same loop machinery as A/B so the
+    /// existing `LoopEvaluator` keeps it bounded automatically.
+    func playSegment(_ segment: ClipSegment) {
+        activeSegmentID = segment.id
+        loopStart = segment.startSeconds
+        loopEnd = segment.endSeconds
+        setSpeed(segment.preferredSpeed)
+        seek(to: segment.startSeconds)
+        play()
+    }
+
+    func clearActiveSegment() {
+        activeSegmentID = nil
+        clearLoop()
     }
 
     // MARK: - Observers

--- a/StepBack/StepBackApp.swift
+++ b/StepBack/StepBackApp.swift
@@ -19,6 +19,6 @@ struct StepBackApp: App {
         WindowGroup {
             RootView()
         }
-        .modelContainer(for: [DanceClip.self, Tag.self, LoopMarker.self])
+        .modelContainer(for: [DanceClip.self, Tag.self, LoopMarker.self, ClipSegment.self])
     }
 }

--- a/StepBack/Views/ClipEditView.swift
+++ b/StepBack/Views/ClipEditView.swift
@@ -214,7 +214,7 @@ struct BulkMoveToGroupView: View {
 
 #Preview {
     let container = try! ModelContainer(
-        for: DanceClip.self, Tag.self, LoopMarker.self,
+        for: DanceClip.self, Tag.self, LoopMarker.self, ClipSegment.self,
         configurations: .init(isStoredInMemoryOnly: true)
     )
     let clip = DanceClip(title: "Sample", assetIdentifier: "preview")

--- a/StepBack/Views/LibraryView.swift
+++ b/StepBack/Views/LibraryView.swift
@@ -622,5 +622,5 @@ enum DeleteConfirmation: Identifiable {
 
 #Preview {
     LibraryView()
-        .modelContainer(for: [DanceClip.self, Tag.self, LoopMarker.self], inMemory: true)
+        .modelContainer(for: [DanceClip.self, Tag.self, LoopMarker.self, ClipSegment.self], inMemory: true)
 }

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -11,6 +11,8 @@ struct PracticeView: View {
     @Environment(\.modelContext) private var modelContext
     @StateObject private var vm: PracticePlayerViewModel
     @State private var markerSheetPresented = false
+    @State private var splitSheetPresented = false
+    @State private var editingSegment: ClipSegment?
     @State private var comparePickerPresented = false
     @State private var compareSecondary: DanceClip?
     @State private var editSheetPresented = false
@@ -82,6 +84,28 @@ struct PracticeView: View {
         .sheet(isPresented: $editSheetPresented) {
             ClipEditView(clip: clip)
                 .preferredColorScheme(.dark)
+        }
+        .sheet(isPresented: $splitSheetPresented) {
+            SegmentSaveSheet(
+                defaultSpeed: vm.speed,
+                defaultRegion: (vm.loopStart ?? 0, vm.loopEnd ?? 0)
+            ) { title, speed in
+                saveSegment(title: title, preferredSpeed: speed)
+            }
+            .presentationDetents([.medium])
+        }
+        .sheet(item: $editingSegment) { segment in
+            SegmentEditSheet(
+                segment: segment,
+                onDelete: {
+                    if vm.activeSegmentID == segment.id {
+                        vm.clearActiveSegment()
+                    }
+                    deleteSegment(segment)
+                }
+            )
+            .presentationDetents([.medium])
+            .preferredColorScheme(.dark)
         }
     }
 
@@ -204,6 +228,12 @@ struct PracticeView: View {
                 onApply: vm.applyMarker,
                 onDelete: deleteMarker
             )
+            SegmentList(
+                segments: clip.segments.sorted { ($0.orderIndex, $0.startSeconds) < ($1.orderIndex, $1.startSeconds) },
+                activeID: vm.activeSegmentID,
+                onPlay: vm.playSegment,
+                onEdit: { editingSegment = $0 }
+            )
         }
         .padding(16)
     }
@@ -227,9 +257,21 @@ struct PracticeView: View {
             Spacer()
             if vm.hasLoopRegion {
                 Button {
+                    splitSheetPresented = true
+                } label: {
+                    Label("Split", systemImage: "scissors")
+                        .font(.system(.footnote, design: .rounded, weight: .semibold))
+                        .foregroundStyle(.black)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(Theme.Color.accent, in: Capsule())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Save A–B as new pattern")
+                Button {
                     markerSheetPresented = true
                 } label: {
-                    Label("Save", systemImage: "bookmark.fill")
+                    Label("Loop", systemImage: "bookmark.fill")
                         .font(.system(.footnote, design: .rounded, weight: .semibold))
                         .foregroundStyle(Theme.Color.accent)
                         .padding(.horizontal, 10)
@@ -271,6 +313,26 @@ extension PracticeView {
 
     fileprivate func deleteMarker(_ marker: LoopMarker) {
         modelContext.delete(marker)
+        try? modelContext.save()
+    }
+
+    fileprivate func saveSegment(title: String, preferredSpeed: Double) {
+        guard let start = vm.loopStart, let end = vm.loopEnd, end > start else { return }
+        let nextIndex = (clip.segments.map(\.orderIndex).max() ?? -1) + 1
+        let segment = ClipSegment(
+            title: title,
+            startSeconds: start,
+            endSeconds: end,
+            preferredSpeed: preferredSpeed,
+            orderIndex: nextIndex,
+            clip: clip
+        )
+        modelContext.insert(segment)
+        try? modelContext.save()
+    }
+
+    fileprivate func deleteSegment(_ segment: ClipSegment) {
+        modelContext.delete(segment)
         try? modelContext.save()
     }
 
@@ -579,5 +641,212 @@ private struct SaveMarkerSheet: View {
             }
         }
         .preferredColorScheme(.dark)
+    }
+}
+
+// MARK: - Segments
+
+private struct SegmentList: View {
+    let segments: [ClipSegment]
+    let activeID: UUID?
+    let onPlay: (ClipSegment) -> Void
+    let onEdit: (ClipSegment) -> Void
+
+    var body: some View {
+        if segments.isEmpty {
+            EmptyView()
+        } else {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Patterns")
+                    .font(.system(.footnote, design: .rounded, weight: .semibold))
+                    .foregroundStyle(Theme.Color.textSecondary)
+                    .padding(.horizontal, 4)
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 10) {
+                        ForEach(segments) { segment in
+                            SegmentCard(
+                                segment: segment,
+                                isActive: segment.id == activeID,
+                                onPlay: { onPlay(segment) },
+                                onEdit: { onEdit(segment) }
+                            )
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+            }
+        }
+    }
+}
+
+private struct SegmentCard: View {
+    let segment: ClipSegment
+    let isActive: Bool
+    let onPlay: () -> Void
+    let onEdit: () -> Void
+
+    var body: some View {
+        Button(action: onPlay) {
+            HStack(spacing: 10) {
+                Image(systemName: isActive ? "waveform" : "play.fill")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundStyle(isActive ? .black : Theme.Color.accent)
+                    .frame(width: 28, height: 28)
+                    .background(
+                        Circle().fill(isActive ? Theme.Color.accent : Theme.Color.accentSoft)
+                    )
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(segment.title)
+                        .font(.system(.footnote, design: .rounded, weight: .semibold))
+                        .foregroundStyle(Theme.Color.textPrimary)
+                        .lineLimit(1)
+                    HStack(spacing: 4) {
+                        Text(SpeedFormatter.timestamp(segment.startSeconds))
+                        Text("–")
+                        Text(SpeedFormatter.timestamp(segment.endSeconds))
+                        if segment.preferredSpeed != 1.0 {
+                            Text("·")
+                            Text(SpeedFormatter.pill(segment.preferredSpeed))
+                        }
+                    }
+                    .font(Theme.Font.timestamp)
+                    .foregroundStyle(Theme.Color.textTertiary)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Theme.Color.surfaceElevated)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(isActive ? Theme.Color.accent : Color.clear, lineWidth: 1.5)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            Button {
+                onEdit()
+            } label: {
+                Label("Rename", systemImage: "pencil")
+            }
+        }
+    }
+}
+
+private struct SegmentSaveSheet: View {
+    let defaultSpeed: Double
+    let defaultRegion: (start: Double, end: Double)
+    let onSave: (String, Double) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var title: String = ""
+    @State private var speed: Double
+
+    init(
+        defaultSpeed: Double,
+        defaultRegion: (start: Double, end: Double),
+        onSave: @escaping (String, Double) -> Void
+    ) {
+        self.defaultSpeed = defaultSpeed
+        self.defaultRegion = defaultRegion
+        self.onSave = onSave
+        _speed = State(initialValue: defaultSpeed)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Pattern name") {
+                    TextField("Basic step", text: $title)
+                }
+                Section("Range") {
+                    LabeledContent("Start", value: SpeedFormatter.timestamp(defaultRegion.start))
+                        .foregroundStyle(Theme.Color.textSecondary)
+                    LabeledContent("End", value: SpeedFormatter.timestamp(defaultRegion.end))
+                        .foregroundStyle(Theme.Color.textSecondary)
+                    LabeledContent("Length", value: SpeedFormatter.timestamp(max(0, defaultRegion.end - defaultRegion.start)))
+                        .foregroundStyle(Theme.Color.textSecondary)
+                }
+                Section("Practice speed") {
+                    SpeedPills(selected: speed, onSelect: { speed = $0 })
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .listRowBackground(Color.clear)
+                }
+            }
+            .scrollContentBackground(.hidden)
+            .background(Theme.Color.background)
+            .navigationTitle("New pattern")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+                        onSave(trimmed.isEmpty ? "Pattern" : trimmed, speed)
+                        dismiss()
+                    }
+                }
+            }
+        }
+        .preferredColorScheme(.dark)
+    }
+}
+
+private struct SegmentEditSheet: View {
+    @Bindable var segment: ClipSegment
+    let onDelete: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Name") {
+                    TextField("Pattern name", text: $segment.title)
+                }
+                Section("Range") {
+                    LabeledContent("Start", value: SpeedFormatter.timestamp(segment.startSeconds))
+                        .foregroundStyle(Theme.Color.textSecondary)
+                    LabeledContent("End", value: SpeedFormatter.timestamp(segment.endSeconds))
+                        .foregroundStyle(Theme.Color.textSecondary)
+                    LabeledContent("Length", value: SpeedFormatter.timestamp(segment.durationSeconds))
+                        .foregroundStyle(Theme.Color.textSecondary)
+                }
+                Section("Practice speed") {
+                    SpeedPills(selected: segment.preferredSpeed, onSelect: { segment.preferredSpeed = $0 })
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .listRowBackground(Color.clear)
+                }
+                Section("Notes") {
+                    TextField("Notes", text: $segment.notes, axis: .vertical)
+                        .lineLimit(3...)
+                }
+                Section {
+                    Button(role: .destructive) {
+                        onDelete()
+                        dismiss()
+                    } label: {
+                        Label("Delete pattern", systemImage: "trash")
+                    }
+                }
+            }
+            .scrollContentBackground(.hidden)
+            .background(Theme.Color.background)
+            .navigationTitle("Edit pattern")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        try? modelContext.save()
+                        dismiss()
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Lets you split a clip into named patterns and practice each one as a bounded loop — the dance-pattern equivalent of "this is the basic step, that's the turn, that's the lift."

- **New `ClipSegment` SwiftData model** with `title`, `startSeconds`, `endSeconds`, `preferredSpeed`, `notes`, `orderIndex`, and a parent `DanceClip`. Cascade-delete from the parent. Added to the schema in `StepBackApp` + previews.
- **Split button** appears next to the Loop save button when an A/B region is set. Opens a sheet to name the pattern and pick a practice speed; saves it as a `ClipSegment` on the current clip.
- **Patterns row** below the marker chips shows every saved segment with title, range, and (if not 1×) preferred speed. Tap a card → loop bounds clamp to its range, speed switches to its preferred speed, playback starts at the segment's start. The active card gets an accent border + waveform glyph so it's obvious which one is playing.
- **Edit / Delete** via context menu on a card → opens a SegmentEditSheet (rename, change practice speed, edit notes, or delete).
- **Coexists with loop markers**. Markers stay in their existing row and are still about saving an A/B loop config; segments are about naming sub-clips of the choreography. Both reuse the same `LoopEvaluator` under the hood, so playback is bounded to whichever range is currently active.
- **Marking new A/B clears the active segment** so the highlighted card doesn't lie about what's looping.

Built on top of the just-merged edit/group PR (#38). Build passes, 65/65 tests pass.

## Test plan

- [ ] Open a clip → set A and B → tap **Split** → name it "Pattern A" → it appears in a new "Patterns" row.
- [ ] Tap the card → playback jumps to the start, loops between A and B at the saved speed, card shows the active border.
- [ ] Save a second pattern from a different A/B; tap to switch — playback rebounds to the new range.
- [ ] Long-press a pattern card → Rename → change name + speed + add a note → Done. Card updates.
- [ ] Long-press → Rename → Delete pattern. Card disappears; if it was active, loop clears.
- [ ] Set a new A or B manually while a pattern is active → active highlight clears (the bounds are no longer the segment's).
- [ ] Saving a Loop (bookmark) marker still works and shows in its own row.
- [ ] Delete the parent clip from the library → segments cascade-delete (no orphan rows next launch).

## Out of scope (follow-ups)

- Library treatment: showing segment count / nested patterns on the clip cell.
- Trim-and-export (actually rendering a new shorter file); the user wants this — separate PR with `AVAssetExportSession`.
- Segment thumbnails (currently the parent clip's thumbnail represents everything).
