### PR TITLE
Trim a clip down and rebase patterns onto the new timeline

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -20,17 +20,21 @@
 		691A3AE86C110C252A1412FE /* BeatGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078CB839E392E788201DD665 /* BeatGrid.swift */; };
 		76D520F6EC5A0A8E57C8AAA1 /* BeatDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6BC077A9FA8B51D07C178A0 /* BeatDetectorTests.swift */; };
 		7FA3BBA0113FDF3282819E84 /* PracticePlayerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */; };
+		9DCAAD9B2DCFAEE83A9D4879 /* TrimView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF9D9B68E730BA51C86D70A /* TrimView.swift */; };
 		9F90D5641396A9BF3E7A09FE /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E94F050959741028A8574D /* RootView.swift */; };
 		A49A15759EECD46EC5E3A694 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D07843122196F5F0DA539D1 /* Theme.swift */; };
 		A88000A1ACD9503F7A9D6143 /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB30650146433E889DC2AF4 /* LibraryView.swift */; };
+		AB9467B4E5F44BFF1AA916B1 /* TrimAnnotationShifterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB991AFC28C64366954E1D19 /* TrimAnnotationShifterTests.swift */; };
 		B3A98425CA93181D0723AB60 /* AutoTagServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C54B956DF5DE01C00D95680 /* AutoTagServiceTests.swift */; };
 		B6CB4CFDF1EB16757B0D78AA /* CompareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D24FDCCE45AEFB352C5EBF /* CompareView.swift */; };
 		BE33E08127A1601493FB7837 /* LoopEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57317F752B65258CB2D04530 /* LoopEvaluatorTests.swift */; };
 		C376AB20647940A9E53A89D0 /* ModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848D52E156E709AA0226CEE8 /* ModelsTests.swift */; };
 		C97E59DA25A51E16ECA03607 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C112AEA59633E85CF8267D /* ThemeTests.swift */; };
+		CBA5E26E730D69F9A3E4944B /* TrimAnnotationShifter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71643D36F7F8D028B560F012 /* TrimAnnotationShifter.swift */; };
 		CC6F98E7716925F88449689A /* PhotosServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */; };
 		D9873262DD68100D8D3C1021 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 462E264B215595E9EC3D1C4A /* Assets.xcassets */; };
 		DA0EE94353A18DA75824D7A8 /* BeatGridTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7093A077C0A2C139BD7BDD29 /* BeatGridTests.swift */; };
+		E709F2C42DEFD624E08A9C35 /* TrimExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCED6C8E1CE7A48B341C8B1 /* TrimExportService.swift */; };
 		E9E06DF791FF47015B3DDFA8 /* BeatDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59BD8F65AE46261EEFD4F69 /* BeatDetector.swift */; };
 		F35848C14CA3DF06A4EBE554 /* SpeedFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E676751B59ED083837CE39 /* SpeedFormatterTests.swift */; };
 		F7AD3FACE8B875F1C9DFA310 /* PhotosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F8476EAB523378C1F1E046 /* PhotosService.swift */; };
@@ -60,7 +64,9 @@
 		56E94F050959741028A8574D /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		57317F752B65258CB2D04530 /* LoopEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopEvaluatorTests.swift; sourceTree = "<group>"; };
 		6745FF48B10D28A5ED4BB568 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
+		6BCED6C8E1CE7A48B341C8B1 /* TrimExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimExportService.swift; sourceTree = "<group>"; };
 		7093A077C0A2C139BD7BDD29 /* BeatGridTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeatGridTests.swift; sourceTree = "<group>"; };
+		71643D36F7F8D028B560F012 /* TrimAnnotationShifter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimAnnotationShifter.swift; sourceTree = "<group>"; };
 		848D52E156E709AA0226CEE8 /* ModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsTests.swift; sourceTree = "<group>"; };
 		8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryFormatterTests.swift; sourceTree = "<group>"; };
 		8D25E6771271EDD5B867F61E /* ClipEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipEditView.swift; sourceTree = "<group>"; };
@@ -76,6 +82,8 @@
 		CC6BAE20433D2ED45F00AD41 /* PracticeBeatUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeBeatUI.swift; sourceTree = "<group>"; };
 		D8F8476EAB523378C1F1E046 /* PhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosService.swift; sourceTree = "<group>"; };
 		DB3B8C1BB7ACE2D1C13C7200 /* StepTimingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepTimingTests.swift; sourceTree = "<group>"; };
+		EAF9D9B68E730BA51C86D70A /* TrimView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimView.swift; sourceTree = "<group>"; };
+		EB991AFC28C64366954E1D19 /* TrimAnnotationShifterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimAnnotationShifterTests.swift; sourceTree = "<group>"; };
 		F6BC077A9FA8B51D07C178A0 /* BeatDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeatDetectorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -106,6 +114,7 @@
 				C35987D9825155E131A40950 /* PracticeControls.swift */,
 				35AE6C8D6564306E1B0ADA20 /* PracticeView.swift */,
 				56E94F050959741028A8574D /* RootView.swift */,
+				EAF9D9B68E730BA51C86D70A /* TrimView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -123,6 +132,7 @@
 				16E676751B59ED083837CE39 /* SpeedFormatterTests.swift */,
 				DB3B8C1BB7ACE2D1C13C7200 /* StepTimingTests.swift */,
 				B7C112AEA59633E85CF8267D /* ThemeTests.swift */,
+				EB991AFC28C64366954E1D19 /* TrimAnnotationShifterTests.swift */,
 			);
 			path = StepBackTests;
 			sourceTree = "<group>";
@@ -136,6 +146,8 @@
 				D8F8476EAB523378C1F1E046 /* PhotosService.swift */,
 				543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */,
 				0265ABC8E91AF4657EB95F83 /* StepTiming.swift */,
+				71643D36F7F8D028B560F012 /* TrimAnnotationShifter.swift */,
+				6BCED6C8E1CE7A48B341C8B1 /* TrimExportService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -284,6 +296,9 @@
 				1EC09265A1CD5B1E67415B39 /* StepBackApp.swift in Sources */,
 				622A6663058E88A57B465B62 /* StepTiming.swift in Sources */,
 				A49A15759EECD46EC5E3A694 /* Theme.swift in Sources */,
+				CBA5E26E730D69F9A3E4944B /* TrimAnnotationShifter.swift in Sources */,
+				E709F2C42DEFD624E08A9C35 /* TrimExportService.swift in Sources */,
+				9DCAAD9B2DCFAEE83A9D4879 /* TrimView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -301,6 +316,7 @@
 				F35848C14CA3DF06A4EBE554 /* SpeedFormatterTests.swift in Sources */,
 				4181110140BD581DBFB0A380 /* StepTimingTests.swift in Sources */,
 				C97E59DA25A51E16ECA03607 /* ThemeTests.swift in Sources */,
+				AB9467B4E5F44BFF1AA916B1 /* TrimAnnotationShifterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/StepBack/Models/Models.swift
+++ b/StepBack/Models/Models.swift
@@ -21,6 +21,9 @@ final class DanceClip: Equatable, Hashable {
     @Relationship(deleteRule: .cascade, inverse: \LoopMarker.clip)
     var loopMarkers: [LoopMarker] = []
 
+    @Relationship(deleteRule: .cascade, inverse: \ClipSegment.clip)
+    var segments: [ClipSegment] = []
+
     var tags: [Tag] = []
 
     init(
@@ -116,5 +119,52 @@ final class LoopMarker {
 
     var durationSeconds: Double {
         max(0, endSeconds - startSeconds)
+    }
+}
+
+@Model
+final class ClipSegment: Equatable, Hashable {
+    var id: UUID
+    var title: String
+    var startSeconds: Double
+    var endSeconds: Double
+    var preferredSpeed: Double
+    var notes: String
+    var dateAdded: Date
+    var orderIndex: Int
+    var clip: DanceClip?
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        startSeconds: Double,
+        endSeconds: Double,
+        preferredSpeed: Double = 1.0,
+        notes: String = "",
+        dateAdded: Date = Date(),
+        orderIndex: Int = 0,
+        clip: DanceClip? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.startSeconds = startSeconds
+        self.endSeconds = endSeconds
+        self.preferredSpeed = preferredSpeed
+        self.notes = notes
+        self.dateAdded = dateAdded
+        self.orderIndex = orderIndex
+        self.clip = clip
+    }
+
+    var durationSeconds: Double {
+        max(0, endSeconds - startSeconds)
+    }
+
+    static func == (lhs: ClipSegment, rhs: ClipSegment) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
     }
 }

--- a/StepBack/Models/Models.swift
+++ b/StepBack/Models/Models.swift
@@ -24,9 +24,6 @@ final class DanceClip: Equatable, Hashable {
     /// original from Photos.
     var trimmedFileName: String?
 
-    @Relationship(deleteRule: .cascade, inverse: \LoopMarker.clip)
-    var loopMarkers: [LoopMarker] = []
-
     @Relationship(deleteRule: .cascade, inverse: \ClipSegment.clip)
     var segments: [ClipSegment] = []
 
@@ -101,36 +98,6 @@ final class Tag {
         self.id = id
         self.name = name
         self.colorHex = colorHex
-    }
-}
-
-@Model
-final class LoopMarker {
-    var id: UUID
-    var label: String
-    var startSeconds: Double
-    var endSeconds: Double
-    var preferredSpeed: Double
-    var clip: DanceClip?
-
-    init(
-        id: UUID = UUID(),
-        label: String,
-        startSeconds: Double,
-        endSeconds: Double,
-        preferredSpeed: Double = 1.0,
-        clip: DanceClip? = nil
-    ) {
-        self.id = id
-        self.label = label
-        self.startSeconds = startSeconds
-        self.endSeconds = endSeconds
-        self.preferredSpeed = preferredSpeed
-        self.clip = clip
-    }
-
-    var durationSeconds: Double {
-        max(0, endSeconds - startSeconds)
     }
 }
 

--- a/StepBack/Models/Models.swift
+++ b/StepBack/Models/Models.swift
@@ -18,6 +18,12 @@ final class DanceClip: Equatable, Hashable {
     var firstDownbeatSeconds: Double?
     var beatsPerMeasure: Int = 4
 
+    /// Filename (in `TrimStorage.directory`) for a sandboxed trimmed copy of
+    /// the original asset. When non-nil, playback resolves to this file
+    /// instead of the PHAsset, so trims survive the user deleting the
+    /// original from Photos.
+    var trimmedFileName: String?
+
     @Relationship(deleteRule: .cascade, inverse: \LoopMarker.clip)
     var loopMarkers: [LoopMarker] = []
 
@@ -73,6 +79,12 @@ final class DanceClip: Equatable, Hashable {
 
     var hasBeatAnalysis: Bool {
         bpm != nil && beatTimesData != nil
+    }
+
+    /// Resolved sandbox URL for a trimmed copy, when one exists.
+    var trimmedFileURL: URL? {
+        guard let trimmedFileName else { return nil }
+        return TrimStorage.fileURL(name: trimmedFileName)
     }
 }
 

--- a/StepBack/Services/PracticePlayerViewModel.swift
+++ b/StepBack/Services/PracticePlayerViewModel.swift
@@ -217,6 +217,7 @@ final class PracticePlayerViewModel: ObservableObject {
         if let end = loopEnd, end <= currentTime {
             loopEnd = nil
         }
+        activeSegmentID = nil
     }
 
     func markLoopEnd() {
@@ -225,11 +226,13 @@ final class PracticePlayerViewModel: ObservableObject {
             return
         }
         loopEnd = currentTime
+        activeSegmentID = nil
     }
 
     func clearLoop() {
         loopStart = nil
         loopEnd = nil
+        activeSegmentID = nil
     }
 
     func applyMarker(_ marker: LoopMarker) {
@@ -237,6 +240,27 @@ final class PracticePlayerViewModel: ObservableObject {
         loopEnd = marker.endSeconds
         setSpeed(marker.preferredSpeed)
         seek(to: marker.startSeconds)
+    }
+
+    // MARK: - Segments
+
+    @Published private(set) var activeSegmentID: UUID?
+
+    /// Plays a segment by clamping the loop region to its bounds and starting
+    /// playback at its start. Reuses the same loop machinery as A/B so the
+    /// existing `LoopEvaluator` keeps it bounded automatically.
+    func playSegment(_ segment: ClipSegment) {
+        activeSegmentID = segment.id
+        loopStart = segment.startSeconds
+        loopEnd = segment.endSeconds
+        setSpeed(segment.preferredSpeed)
+        seek(to: segment.startSeconds)
+        play()
+    }
+
+    func clearActiveSegment() {
+        activeSegmentID = nil
+        clearLoop()
     }
 
     // MARK: - Observers

--- a/StepBack/Services/PracticePlayerViewModel.swift
+++ b/StepBack/Services/PracticePlayerViewModel.swift
@@ -261,13 +261,6 @@ final class PracticePlayerViewModel: ObservableObject {
         activeSegmentID = nil
     }
 
-    func applyMarker(_ marker: LoopMarker) {
-        loopStart = marker.startSeconds
-        loopEnd = marker.endSeconds
-        setSpeed(marker.preferredSpeed)
-        seek(to: marker.startSeconds)
-    }
-
     // MARK: - Segments
 
     @Published private(set) var activeSegmentID: UUID?

--- a/StepBack/Services/PracticePlayerViewModel.swift
+++ b/StepBack/Services/PracticePlayerViewModel.swift
@@ -32,14 +32,17 @@ final class PracticePlayerViewModel: ObservableObject {
     private var playerItem: AVPlayerItem?
 
     private let assetIdentifier: String
+    private var localFileURL: URL?
     private let photosService: PhotosServicing
 
     init(
         assetIdentifier: String,
+        localFileURL: URL? = nil,
         photosService: PhotosServicing = PhotosService(),
         player: AVPlayer = AVPlayer()
     ) {
         self.assetIdentifier = assetIdentifier
+        self.localFileURL = localFileURL
         self.photosService = photosService
         self.player = player
         attachTimeObserver()
@@ -53,10 +56,33 @@ final class PracticePlayerViewModel: ObservableObject {
 
     // MARK: - Loading
 
+    /// Swaps the underlying source (e.g. after a trim writes a new file) and
+    /// reloads. Resets transport state so the user doesn't end up paused at
+    /// a timestamp that no longer exists in the new timeline.
+    func reloadAsset(localFileURL: URL?) async {
+        self.localFileURL = localFileURL
+        pause()
+        loopStart = nil
+        loopEnd = nil
+        activeSegmentID = nil
+        currentTime = 0
+        duration = 0
+        isReady = false
+        loadError = nil
+        player.replaceCurrentItem(with: nil)
+        playerItem = nil
+        await load()
+    }
+
     func load() async {
         guard !isReady else { return }
         do {
-            let urlAsset = try await photosService.resolveAVAsset(for: assetIdentifier)
+            let urlAsset: AVURLAsset
+            if let localFileURL {
+                urlAsset = AVURLAsset(url: localFileURL)
+            } else {
+                urlAsset = try await photosService.resolveAVAsset(for: assetIdentifier)
+            }
             let loadedDuration = try await urlAsset.load(.duration).seconds
             let item = AVPlayerItem(asset: urlAsset)
             item.audioTimePitchAlgorithm = .timeDomain

--- a/StepBack/Services/TrimAnnotationShifter.swift
+++ b/StepBack/Services/TrimAnnotationShifter.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Pure logic for "I just trimmed [trimStart, trimEnd] out of a clip — how
+/// do I rebase the annotations?" Anything outside the new window is dropped;
+/// anything that straddles an edge is clamped. Times are returned in the
+/// new clip's timeline (i.e. with `trimStart` already subtracted).
+enum TrimAnnotationShifter {
+
+    struct ShiftedRange: Equatable {
+        var start: Double
+        var end: Double
+    }
+
+    /// Shifts a single time point. Returns nil if the point falls outside
+    /// the kept range.
+    static func shiftPoint(
+        _ time: Double,
+        trimStart: Double,
+        trimEnd: Double
+    ) -> Double? {
+        guard time >= trimStart, time <= trimEnd else { return nil }
+        return time - trimStart
+    }
+
+    /// Shifts a [start, end] range. Returns nil if the entire range falls
+    /// outside the kept window or collapses to zero length after clamping.
+    static func shiftRange(
+        start: Double,
+        end: Double,
+        trimStart: Double,
+        trimEnd: Double,
+        minimumDuration: Double = 0.05
+    ) -> ShiftedRange? {
+        guard end > start else { return nil }
+        guard end > trimStart, start < trimEnd else { return nil }
+        let clampedStart = max(start, trimStart)
+        let clampedEnd = min(end, trimEnd)
+        guard clampedEnd - clampedStart >= minimumDuration else { return nil }
+        return ShiftedRange(
+            start: clampedStart - trimStart,
+            end: clampedEnd - trimStart
+        )
+    }
+
+    /// Drops beat times outside the kept window and rebases the rest.
+    static func shiftBeatTimes(
+        _ times: [Double],
+        trimStart: Double,
+        trimEnd: Double
+    ) -> [Double] {
+        times.compactMap { shiftPoint($0, trimStart: trimStart, trimEnd: trimEnd) }
+    }
+}

--- a/StepBack/Services/TrimExportService.swift
+++ b/StepBack/Services/TrimExportService.swift
@@ -1,0 +1,98 @@
+import AVFoundation
+import Foundation
+
+enum TrimError: Error, LocalizedError {
+    case invalidRange
+    case exportFailed(String)
+    case unknownExportState
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidRange:
+            return "The selected range is empty."
+        case .exportFailed(let detail):
+            return "Trim failed: \(detail)"
+        case .unknownExportState:
+            return "Trim ended in an unknown state."
+        }
+    }
+}
+
+/// Where trimmed clip files live inside the app sandbox. We keep these
+/// out of `tmp` so they survive backgrounding and reboot, and out of
+/// `caches` because we can't afford the OS reclaiming them mid-practice.
+enum TrimStorage {
+    static var directory: URL {
+        FileManager.default
+            .urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("Trims", isDirectory: true)
+    }
+
+    static func ensureDirectoryExists() throws {
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+    }
+
+    static func fileURL(name: String) -> URL {
+        directory.appendingPathComponent(name)
+    }
+
+    static func deleteIfExists(name: String) {
+        let url = fileURL(name: name)
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+/// Exports a sub-range of an `AVAsset` to the sandbox using the passthrough
+/// preset (no re-encode → fast, no quality loss). The caller owns the
+/// returned filename; `TrimStorage.directory` resolves it back to a URL.
+struct TrimExportService {
+
+    func export(
+        asset: AVAsset,
+        start: Double,
+        end: Double
+    ) async throws -> (fileName: String, durationSeconds: Double) {
+        let trimmed = max(0, end - start)
+        guard trimmed > 0.05 else { throw TrimError.invalidRange }
+
+        try TrimStorage.ensureDirectoryExists()
+
+        let fileName = "\(UUID().uuidString).mov"
+        let outputURL = TrimStorage.fileURL(name: fileName)
+        // Stale temp from a prior crashed export.
+        try? FileManager.default.removeItem(at: outputURL)
+
+        guard let session = AVAssetExportSession(
+            asset: asset,
+            presetName: AVAssetExportPresetPassthrough
+        ) else {
+            throw TrimError.exportFailed("Couldn't create export session.")
+        }
+
+        session.outputURL = outputURL
+        session.outputFileType = .mov
+        session.shouldOptimizeForNetworkUse = false
+        let timescale: CMTimeScale = 600
+        session.timeRange = CMTimeRange(
+            start: CMTime(seconds: start, preferredTimescale: timescale),
+            end: CMTime(seconds: end, preferredTimescale: timescale)
+        )
+
+        await session.export()
+
+        switch session.status {
+        case .completed:
+            return (fileName, trimmed)
+        case .failed, .cancelled:
+            try? FileManager.default.removeItem(at: outputURL)
+            let detail = session.error?.localizedDescription ?? "unknown"
+            throw TrimError.exportFailed(detail)
+        default:
+            try? FileManager.default.removeItem(at: outputURL)
+            throw TrimError.unknownExportState
+        }
+    }
+}

--- a/StepBack/StepBackApp.swift
+++ b/StepBack/StepBackApp.swift
@@ -19,6 +19,6 @@ struct StepBackApp: App {
         WindowGroup {
             RootView()
         }
-        .modelContainer(for: [DanceClip.self, Tag.self, LoopMarker.self])
+        .modelContainer(for: [DanceClip.self, Tag.self, LoopMarker.self, ClipSegment.self])
     }
 }

--- a/StepBack/StepBackApp.swift
+++ b/StepBack/StepBackApp.swift
@@ -19,6 +19,6 @@ struct StepBackApp: App {
         WindowGroup {
             RootView()
         }
-        .modelContainer(for: [DanceClip.self, Tag.self, LoopMarker.self, ClipSegment.self])
+        .modelContainer(for: [DanceClip.self, Tag.self, ClipSegment.self])
     }
 }

--- a/StepBack/Views/ClipEditView.swift
+++ b/StepBack/Views/ClipEditView.swift
@@ -214,7 +214,7 @@ struct BulkMoveToGroupView: View {
 
 #Preview {
     let container = try! ModelContainer(
-        for: DanceClip.self, Tag.self, LoopMarker.self,
+        for: DanceClip.self, Tag.self, LoopMarker.self, ClipSegment.self,
         configurations: .init(isStoredInMemoryOnly: true)
     )
     let clip = DanceClip(title: "Sample", assetIdentifier: "preview")

--- a/StepBack/Views/ClipEditView.swift
+++ b/StepBack/Views/ClipEditView.swift
@@ -214,7 +214,7 @@ struct BulkMoveToGroupView: View {
 
 #Preview {
     let container = try! ModelContainer(
-        for: DanceClip.self, Tag.self, LoopMarker.self, ClipSegment.self,
+        for: DanceClip.self, Tag.self, ClipSegment.self,
         configurations: .init(isStoredInMemoryOnly: true)
     )
     let clip = DanceClip(title: "Sample", assetIdentifier: "preview")

--- a/StepBack/Views/CompareView.swift
+++ b/StepBack/Views/CompareView.swift
@@ -19,10 +19,16 @@ struct CompareView: View {
         self.primaryClip = primary
         self.secondaryClip = secondary
         _primary = StateObject(
-            wrappedValue: PracticePlayerViewModel(assetIdentifier: primary.assetIdentifier)
+            wrappedValue: PracticePlayerViewModel(
+                assetIdentifier: primary.assetIdentifier,
+                localFileURL: primary.trimmedFileURL
+            )
         )
         _secondary = StateObject(
-            wrappedValue: PracticePlayerViewModel(assetIdentifier: secondary.assetIdentifier)
+            wrappedValue: PracticePlayerViewModel(
+                assetIdentifier: secondary.assetIdentifier,
+                localFileURL: secondary.trimmedFileURL
+            )
         )
     }
 

--- a/StepBack/Views/LibraryView.swift
+++ b/StepBack/Views/LibraryView.swift
@@ -622,5 +622,5 @@ enum DeleteConfirmation: Identifiable {
 
 #Preview {
     LibraryView()
-        .modelContainer(for: [DanceClip.self, Tag.self, LoopMarker.self, ClipSegment.self], inMemory: true)
+        .modelContainer(for: [DanceClip.self, Tag.self, ClipSegment.self], inMemory: true)
 }

--- a/StepBack/Views/LibraryView.swift
+++ b/StepBack/Views/LibraryView.swift
@@ -622,5 +622,5 @@ enum DeleteConfirmation: Identifiable {
 
 #Preview {
     LibraryView()
-        .modelContainer(for: [DanceClip.self, Tag.self, LoopMarker.self], inMemory: true)
+        .modelContainer(for: [DanceClip.self, Tag.self, LoopMarker.self, ClipSegment.self], inMemory: true)
 }

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -13,6 +13,7 @@ struct PracticeView: View {
     @State private var markerSheetPresented = false
     @State private var splitSheetPresented = false
     @State private var editingSegment: ClipSegment?
+    @State private var trimSheetPresented = false
     @State private var comparePickerPresented = false
     @State private var compareSecondary: DanceClip?
     @State private var editSheetPresented = false
@@ -20,7 +21,10 @@ struct PracticeView: View {
     init(clip: DanceClip) {
         self.clip = clip
         _vm = StateObject(
-            wrappedValue: PracticePlayerViewModel(assetIdentifier: clip.assetIdentifier)
+            wrappedValue: PracticePlayerViewModel(
+                assetIdentifier: clip.assetIdentifier,
+                localFileURL: clip.trimmedFileURL
+            )
         )
     }
 
@@ -43,6 +47,14 @@ struct PracticeView: View {
                             .foregroundStyle(Theme.Color.textPrimary)
                     }
                     .accessibilityLabel("Edit clip")
+                    Button {
+                        vm.pause()
+                        trimSheetPresented = true
+                    } label: {
+                        Image(systemName: "crop")
+                            .foregroundStyle(Theme.Color.textPrimary)
+                    }
+                    .accessibilityLabel("Trim clip")
                     Button {
                         comparePickerPresented = true
                     } label: {
@@ -93,6 +105,12 @@ struct PracticeView: View {
                 saveSegment(title: title, preferredSpeed: speed)
             }
             .presentationDetents([.medium])
+        }
+        .fullScreenCover(isPresented: $trimSheetPresented, onDismiss: {
+            // After a trim the underlying file has changed; rebind the player.
+            Task { await vm.reloadAsset(localFileURL: clip.trimmedFileURL) }
+        }) {
+            TrimView(clip: clip)
         }
         .sheet(item: $editingSegment) { segment in
             SegmentEditSheet(

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -11,6 +11,8 @@ struct PracticeView: View {
     @Environment(\.modelContext) private var modelContext
     @StateObject private var vm: PracticePlayerViewModel
     @State private var markerSheetPresented = false
+    @State private var splitSheetPresented = false
+    @State private var editingSegment: ClipSegment?
     @State private var comparePickerPresented = false
     @State private var compareSecondary: DanceClip?
     @State private var editSheetPresented = false
@@ -82,6 +84,28 @@ struct PracticeView: View {
         .sheet(isPresented: $editSheetPresented) {
             ClipEditView(clip: clip)
                 .preferredColorScheme(.dark)
+        }
+        .sheet(isPresented: $splitSheetPresented) {
+            SegmentSaveSheet(
+                defaultSpeed: vm.speed,
+                defaultRegion: (vm.loopStart ?? 0, vm.loopEnd ?? 0)
+            ) { title, speed in
+                saveSegment(title: title, preferredSpeed: speed)
+            }
+            .presentationDetents([.medium])
+        }
+        .sheet(item: $editingSegment) { segment in
+            SegmentEditSheet(
+                segment: segment,
+                onDelete: {
+                    if vm.activeSegmentID == segment.id {
+                        vm.clearActiveSegment()
+                    }
+                    deleteSegment(segment)
+                }
+            )
+            .presentationDetents([.medium])
+            .preferredColorScheme(.dark)
         }
     }
 
@@ -204,6 +228,12 @@ struct PracticeView: View {
                 onApply: vm.applyMarker,
                 onDelete: deleteMarker
             )
+            SegmentList(
+                segments: clip.segments.sorted { ($0.orderIndex, $0.startSeconds) < ($1.orderIndex, $1.startSeconds) },
+                activeID: vm.activeSegmentID,
+                onPlay: vm.playSegment,
+                onEdit: { editingSegment = $0 }
+            )
         }
         .padding(16)
     }
@@ -227,9 +257,21 @@ struct PracticeView: View {
             Spacer()
             if vm.hasLoopRegion {
                 Button {
+                    splitSheetPresented = true
+                } label: {
+                    Label("Split", systemImage: "scissors")
+                        .font(.system(.footnote, design: .rounded, weight: .semibold))
+                        .foregroundStyle(.black)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(Theme.Color.accent, in: Capsule())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Save A–B as new pattern")
+                Button {
                     markerSheetPresented = true
                 } label: {
-                    Label("Save", systemImage: "bookmark.fill")
+                    Label("Loop", systemImage: "bookmark.fill")
                         .font(.system(.footnote, design: .rounded, weight: .semibold))
                         .foregroundStyle(Theme.Color.accent)
                         .padding(.horizontal, 10)
@@ -271,6 +313,26 @@ extension PracticeView {
 
     fileprivate func deleteMarker(_ marker: LoopMarker) {
         modelContext.delete(marker)
+        try? modelContext.save()
+    }
+
+    fileprivate func saveSegment(title: String, preferredSpeed: Double) {
+        guard let start = vm.loopStart, let end = vm.loopEnd, end > start else { return }
+        let nextIndex = (clip.segments.map(\.orderIndex).max() ?? -1) + 1
+        let segment = ClipSegment(
+            title: title,
+            startSeconds: start,
+            endSeconds: end,
+            preferredSpeed: preferredSpeed,
+            orderIndex: nextIndex,
+            clip: clip
+        )
+        modelContext.insert(segment)
+        try? modelContext.save()
+    }
+
+    fileprivate func deleteSegment(_ segment: ClipSegment) {
+        modelContext.delete(segment)
         try? modelContext.save()
     }
 
@@ -579,5 +641,212 @@ private struct SaveMarkerSheet: View {
             }
         }
         .preferredColorScheme(.dark)
+    }
+}
+
+// MARK: - Segments
+
+private struct SegmentList: View {
+    let segments: [ClipSegment]
+    let activeID: UUID?
+    let onPlay: (ClipSegment) -> Void
+    let onEdit: (ClipSegment) -> Void
+
+    var body: some View {
+        if segments.isEmpty {
+            EmptyView()
+        } else {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Patterns")
+                    .font(.system(.footnote, design: .rounded, weight: .semibold))
+                    .foregroundStyle(Theme.Color.textSecondary)
+                    .padding(.horizontal, 4)
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 10) {
+                        ForEach(segments) { segment in
+                            SegmentCard(
+                                segment: segment,
+                                isActive: segment.id == activeID,
+                                onPlay: { onPlay(segment) },
+                                onEdit: { onEdit(segment) }
+                            )
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+            }
+        }
+    }
+}
+
+private struct SegmentCard: View {
+    let segment: ClipSegment
+    let isActive: Bool
+    let onPlay: () -> Void
+    let onEdit: () -> Void
+
+    var body: some View {
+        Button(action: onPlay) {
+            HStack(spacing: 10) {
+                Image(systemName: isActive ? "waveform" : "play.fill")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundStyle(isActive ? .black : Theme.Color.accent)
+                    .frame(width: 28, height: 28)
+                    .background(
+                        Circle().fill(isActive ? Theme.Color.accent : Theme.Color.accentSoft)
+                    )
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(segment.title)
+                        .font(.system(.footnote, design: .rounded, weight: .semibold))
+                        .foregroundStyle(Theme.Color.textPrimary)
+                        .lineLimit(1)
+                    HStack(spacing: 4) {
+                        Text(SpeedFormatter.timestamp(segment.startSeconds))
+                        Text("–")
+                        Text(SpeedFormatter.timestamp(segment.endSeconds))
+                        if segment.preferredSpeed != 1.0 {
+                            Text("·")
+                            Text(SpeedFormatter.pill(segment.preferredSpeed))
+                        }
+                    }
+                    .font(Theme.Font.timestamp)
+                    .foregroundStyle(Theme.Color.textTertiary)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Theme.Color.surfaceElevated)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(isActive ? Theme.Color.accent : Color.clear, lineWidth: 1.5)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            Button {
+                onEdit()
+            } label: {
+                Label("Rename", systemImage: "pencil")
+            }
+        }
+    }
+}
+
+private struct SegmentSaveSheet: View {
+    let defaultSpeed: Double
+    let defaultRegion: (start: Double, end: Double)
+    let onSave: (String, Double) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var title: String = ""
+    @State private var speed: Double
+
+    init(
+        defaultSpeed: Double,
+        defaultRegion: (start: Double, end: Double),
+        onSave: @escaping (String, Double) -> Void
+    ) {
+        self.defaultSpeed = defaultSpeed
+        self.defaultRegion = defaultRegion
+        self.onSave = onSave
+        _speed = State(initialValue: defaultSpeed)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Pattern name") {
+                    TextField("Basic step", text: $title)
+                }
+                Section("Range") {
+                    LabeledContent("Start", value: SpeedFormatter.timestamp(defaultRegion.start))
+                        .foregroundStyle(Theme.Color.textSecondary)
+                    LabeledContent("End", value: SpeedFormatter.timestamp(defaultRegion.end))
+                        .foregroundStyle(Theme.Color.textSecondary)
+                    LabeledContent("Length", value: SpeedFormatter.timestamp(max(0, defaultRegion.end - defaultRegion.start)))
+                        .foregroundStyle(Theme.Color.textSecondary)
+                }
+                Section("Practice speed") {
+                    SpeedPills(selected: speed, onSelect: { speed = $0 })
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .listRowBackground(Color.clear)
+                }
+            }
+            .scrollContentBackground(.hidden)
+            .background(Theme.Color.background)
+            .navigationTitle("New pattern")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+                        onSave(trimmed.isEmpty ? "Pattern" : trimmed, speed)
+                        dismiss()
+                    }
+                }
+            }
+        }
+        .preferredColorScheme(.dark)
+    }
+}
+
+private struct SegmentEditSheet: View {
+    @Bindable var segment: ClipSegment
+    let onDelete: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Name") {
+                    TextField("Pattern name", text: $segment.title)
+                }
+                Section("Range") {
+                    LabeledContent("Start", value: SpeedFormatter.timestamp(segment.startSeconds))
+                        .foregroundStyle(Theme.Color.textSecondary)
+                    LabeledContent("End", value: SpeedFormatter.timestamp(segment.endSeconds))
+                        .foregroundStyle(Theme.Color.textSecondary)
+                    LabeledContent("Length", value: SpeedFormatter.timestamp(segment.durationSeconds))
+                        .foregroundStyle(Theme.Color.textSecondary)
+                }
+                Section("Practice speed") {
+                    SpeedPills(selected: segment.preferredSpeed, onSelect: { segment.preferredSpeed = $0 })
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .listRowBackground(Color.clear)
+                }
+                Section("Notes") {
+                    TextField("Notes", text: $segment.notes, axis: .vertical)
+                        .lineLimit(3...)
+                }
+                Section {
+                    Button(role: .destructive) {
+                        onDelete()
+                        dismiss()
+                    } label: {
+                        Label("Delete pattern", systemImage: "trash")
+                    }
+                }
+            }
+            .scrollContentBackground(.hidden)
+            .background(Theme.Color.background)
+            .navigationTitle("Edit pattern")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        try? modelContext.save()
+                        dismiss()
+                    }
+                }
+            }
+        }
     }
 }

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -10,7 +10,6 @@ struct PracticeView: View {
 
     @Environment(\.modelContext) private var modelContext
     @StateObject private var vm: PracticePlayerViewModel
-    @State private var markerSheetPresented = false
     @State private var splitSheetPresented = false
     @State private var editingSegment: ClipSegment?
     @State private var trimSheetPresented = false
@@ -83,15 +82,6 @@ struct PracticeView: View {
         }
         .navigationDestination(item: $compareSecondary) { secondary in
             CompareView(primary: clip, secondary: secondary)
-        }
-        .sheet(isPresented: $markerSheetPresented) {
-            SaveMarkerSheet(
-                defaultSpeed: vm.speed,
-                defaultRegion: (vm.loopStart ?? 0, vm.loopEnd ?? 0)
-            ) { label, speed in
-                saveMarker(label: label, speed: speed)
-            }
-            .presentationDetents([.medium])
         }
         .sheet(isPresented: $editSheetPresented) {
             ClipEditView(clip: clip)
@@ -241,11 +231,6 @@ struct PracticeView: View {
                 Spacer()
             }
             SpeedPills(selected: vm.speed, onSelect: vm.setSpeed(_:))
-            MarkerList(
-                markers: clip.loopMarkers.sorted { $0.startSeconds < $1.startSeconds },
-                onApply: vm.applyMarker,
-                onDelete: deleteMarker
-            )
             SegmentList(
                 segments: clip.segments.sorted { ($0.orderIndex, $0.startSeconds) < ($1.orderIndex, $1.startSeconds) },
                 activeID: vm.activeSegmentID,
@@ -286,17 +271,6 @@ struct PracticeView: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Save A–B as new pattern")
-                Button {
-                    markerSheetPresented = true
-                } label: {
-                    Label("Loop", systemImage: "bookmark.fill")
-                        .font(.system(.footnote, design: .rounded, weight: .semibold))
-                        .foregroundStyle(Theme.Color.accent)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 6)
-                        .background(Theme.Color.accentSoft, in: Capsule())
-                }
-                .buttonStyle(.plain)
             }
             if vm.loopStart != nil || vm.loopEnd != nil {
                 Button {
@@ -316,24 +290,6 @@ struct PracticeView: View {
 // MARK: - Persistence + command helpers
 
 extension PracticeView {
-    fileprivate func saveMarker(label: String, speed: Double) {
-        guard let start = vm.loopStart, let end = vm.loopEnd, end > start else { return }
-        let marker = LoopMarker(
-            label: label,
-            startSeconds: start,
-            endSeconds: end,
-            preferredSpeed: speed,
-            clip: clip
-        )
-        modelContext.insert(marker)
-        try? modelContext.save()
-    }
-
-    fileprivate func deleteMarker(_ marker: LoopMarker) {
-        modelContext.delete(marker)
-        try? modelContext.save()
-    }
-
     fileprivate func saveSegment(title: String, preferredSpeed: Double) {
         guard let start = vm.loopStart, let end = vm.loopEnd, end > start else { return }
         let nextIndex = (clip.segments.map(\.orderIndex).max() ?? -1) + 1
@@ -536,129 +492,6 @@ private struct LoopButton: View {
             }
         }
         .buttonStyle(.plain)
-    }
-}
-
-// MARK: - Markers
-
-private struct MarkerList: View {
-    let markers: [LoopMarker]
-    let onApply: (LoopMarker) -> Void
-    let onDelete: (LoopMarker) -> Void
-
-    var body: some View {
-        if markers.isEmpty {
-            EmptyView()
-        } else {
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 8) {
-                    ForEach(markers) { marker in
-                        MarkerChip(marker: marker, onApply: onApply, onDelete: onDelete)
-                    }
-                }
-                .padding(.vertical, 4)
-            }
-        }
-    }
-}
-
-private struct MarkerChip: View {
-    let marker: LoopMarker
-    let onApply: (LoopMarker) -> Void
-    let onDelete: (LoopMarker) -> Void
-
-    var body: some View {
-        Button {
-            onApply(marker)
-        } label: {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(marker.label)
-                    .font(.system(.footnote, design: .rounded, weight: .semibold))
-                    .foregroundStyle(Theme.Color.textPrimary)
-                    .lineLimit(1)
-                HStack(spacing: 4) {
-                    Text(SpeedFormatter.timestamp(marker.startSeconds))
-                    Text("–")
-                    Text(SpeedFormatter.timestamp(marker.endSeconds))
-                    Text("·")
-                    Text(SpeedFormatter.pill(marker.preferredSpeed))
-                }
-                .font(Theme.Font.timestamp)
-                .foregroundStyle(Theme.Color.textTertiary)
-            }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 8)
-            .background(Theme.Color.surfaceElevated, in: RoundedRectangle(cornerRadius: 10))
-        }
-        .buttonStyle(.plain)
-        .contextMenu {
-            Button(role: .destructive) {
-                onDelete(marker)
-            } label: {
-                Label("Delete marker", systemImage: "trash")
-            }
-        }
-    }
-}
-
-// MARK: - Save marker sheet
-
-private struct SaveMarkerSheet: View {
-    let defaultSpeed: Double
-    let defaultRegion: (start: Double, end: Double)
-    let onSave: (String, Double) -> Void
-
-    @Environment(\.dismiss) private var dismiss
-    @State private var label: String = ""
-    @State private var speed: Double
-
-    init(
-        defaultSpeed: Double,
-        defaultRegion: (start: Double, end: Double),
-        onSave: @escaping (String, Double) -> Void
-    ) {
-        self.defaultSpeed = defaultSpeed
-        self.defaultRegion = defaultRegion
-        self.onSave = onSave
-        _speed = State(initialValue: defaultSpeed)
-    }
-
-    var body: some View {
-        NavigationStack {
-            Form {
-                Section("Name") {
-                    TextField("Hard 8-count", text: $label)
-                }
-                Section("Region") {
-                    LabeledContent("Start", value: SpeedFormatter.timestamp(defaultRegion.start))
-                        .foregroundStyle(Theme.Color.textSecondary)
-                    LabeledContent("End", value: SpeedFormatter.timestamp(defaultRegion.end))
-                        .foregroundStyle(Theme.Color.textSecondary)
-                }
-                Section("Preferred speed") {
-                    SpeedPills(selected: speed, onSelect: { speed = $0 })
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .listRowBackground(Color.clear)
-                }
-            }
-            .scrollContentBackground(.hidden)
-            .background(Theme.Color.background)
-            .navigationTitle("Save loop")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
-                }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Save") {
-                        let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
-                        onSave(trimmed.isEmpty ? "Marker" : trimmed, speed)
-                        dismiss()
-                    }
-                }
-            }
-        }
-        .preferredColorScheme(.dark)
     }
 }
 

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -47,7 +47,11 @@ struct PracticeView: View {
                     }
                     .accessibilityLabel("Edit clip")
                     Button {
+                        // Park the parent VM in a neutral state — loop bounds and
+                        // segment selection would fight TrimView's own seeking
+                        // since they share an AVPlayer.
                         vm.pause()
+                        vm.clearLoop()
                         trimSheetPresented = true
                     } label: {
                         Image(systemName: "crop")
@@ -100,7 +104,7 @@ struct PracticeView: View {
             // After a trim the underlying file has changed; rebind the player.
             Task { await vm.reloadAsset(localFileURL: clip.trimmedFileURL) }
         }) {
-            TrimView(clip: clip)
+            TrimView(clip: clip, player: vm.player, initialDuration: vm.duration)
         }
         .sheet(item: $editingSegment) { segment in
             SegmentEditSheet(

--- a/StepBack/Views/TrimView.swift
+++ b/StepBack/Views/TrimView.swift
@@ -272,20 +272,6 @@ struct TrimView: View {
             TrimAnnotationShifter.shiftBeatTimes(clip.beatTimes, trimStart: start, trimEnd: end)
         )
 
-        for marker in clip.loopMarkers {
-            if let shifted = TrimAnnotationShifter.shiftRange(
-                start: marker.startSeconds,
-                end: marker.endSeconds,
-                trimStart: start,
-                trimEnd: end
-            ) {
-                marker.startSeconds = shifted.start
-                marker.endSeconds = shifted.end
-            } else {
-                modelContext.delete(marker)
-            }
-        }
-
         for segment in clip.segments {
             if let shifted = TrimAnnotationShifter.shiftRange(
                 start: segment.startSeconds,

--- a/StepBack/Views/TrimView.swift
+++ b/StepBack/Views/TrimView.swift
@@ -1,0 +1,435 @@
+import AVFoundation
+import AVKit
+import SwiftData
+import SwiftUI
+import UIKit
+
+/// Modal trim editor. Plays the clip muted in a loop within the chosen
+/// [start, end] window so the user can audition the trim, then exports
+/// the range to the sandbox and rebases all annotations on the new
+/// timeline.
+struct TrimView: View {
+
+    let clip: DanceClip
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+
+    @StateObject private var preview: PracticePlayerViewModel
+    @State private var trimStart: Double = 0
+    @State private var trimEnd: Double = 0
+    @State private var isExporting = false
+    @State private var exportError: String?
+    @State private var hasInitializedHandles = false
+
+    init(clip: DanceClip) {
+        self.clip = clip
+        _preview = StateObject(
+            wrappedValue: PracticePlayerViewModel(
+                assetIdentifier: clip.assetIdentifier,
+                localFileURL: clip.trimmedFileURL
+            )
+        )
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.Color.background.ignoresSafeArea()
+                content
+            }
+            .navigationTitle("Trim clip")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .disabled(isExporting)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Apply") {
+                        Task { await applyTrim() }
+                    }
+                    .disabled(!canApply || isExporting)
+                }
+            }
+        }
+        .task { await preview.load() }
+        .onChange(of: preview.duration) { _, newDuration in
+            if !hasInitializedHandles, newDuration > 0 {
+                trimStart = 0
+                trimEnd = newDuration
+                hasInitializedHandles = true
+                preview.seek(to: 0)
+            }
+        }
+        .onChange(of: preview.currentTime) { _, t in
+            // Loop preview within the chosen window.
+            if t >= trimEnd, preview.duration > 0 {
+                preview.seek(to: trimStart)
+            }
+        }
+        .preferredColorScheme(.dark)
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        if let error = preview.loadError {
+            errorState(message: error)
+        } else if !preview.isReady {
+            ProgressView().tint(Theme.Color.accent)
+        } else {
+            VStack(spacing: 16) {
+                videoPanel
+                handles
+                preset
+                if let exportError {
+                    Text(exportError)
+                        .font(Theme.Font.caption)
+                        .foregroundStyle(.red.opacity(0.9))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 16)
+                }
+                if isExporting {
+                    HStack(spacing: 8) {
+                        ProgressView().tint(Theme.Color.accent)
+                        Text("Exporting…")
+                            .font(Theme.Font.caption)
+                            .foregroundStyle(Theme.Color.textSecondary)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.top, 8)
+        }
+    }
+
+    private var videoPanel: some View {
+        TrimPlayerSurface(player: preview.player)
+            .aspectRatio(16.0 / 9.0, contentMode: .fit)
+            .background(Color.black)
+            .overlay(alignment: .bottom) {
+                HStack {
+                    Button {
+                        preview.togglePlayPause()
+                    } label: {
+                        Image(systemName: preview.isPlaying ? "pause.fill" : "play.fill")
+                            .font(.system(size: 14, weight: .bold))
+                            .foregroundStyle(.black)
+                            .frame(width: 36, height: 36)
+                            .background(Theme.Color.accent, in: Circle())
+                    }
+                    .buttonStyle(.plain)
+                    Spacer()
+                    Text("\(SpeedFormatter.timestamp(preview.currentTime)) / \(SpeedFormatter.timestamp(preview.duration))")
+                        .font(Theme.Font.timestamp)
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(.black.opacity(0.4), in: Capsule())
+                }
+                .padding(8)
+            }
+    }
+
+    private var handles: some View {
+        VStack(spacing: 10) {
+            TrimRangeBar(
+                duration: max(preview.duration, 0.001),
+                currentTime: preview.currentTime,
+                trimStart: $trimStart,
+                trimEnd: $trimEnd,
+                onSeek: { preview.seek(to: $0) }
+            )
+            HStack {
+                rangeChip(
+                    label: "Start",
+                    value: trimStart,
+                    set: {
+                        trimStart = preview.currentTime
+                        if trimEnd <= trimStart + 0.05 {
+                            trimEnd = min(preview.duration, trimStart + 0.5)
+                        }
+                    }
+                )
+                Spacer()
+                Text(SpeedFormatter.timestamp(max(0, trimEnd - trimStart)))
+                    .font(.system(.footnote, design: .rounded, weight: .semibold))
+                    .foregroundStyle(Theme.Color.accent)
+                Spacer()
+                rangeChip(
+                    label: "End",
+                    value: trimEnd,
+                    set: {
+                        trimEnd = preview.currentTime
+                        if trimStart >= trimEnd - 0.05 {
+                            trimStart = max(0, trimEnd - 0.5)
+                        }
+                    }
+                )
+            }
+            .padding(.horizontal, 16)
+        }
+        .padding(.horizontal, 8)
+    }
+
+    private var preset: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Heads up")
+                .font(.system(.footnote, design: .rounded, weight: .semibold))
+                .foregroundStyle(Theme.Color.textSecondary)
+            Text("Trimming replaces the clip's source with a new file. Patterns, loops, and beat times are kept and shifted to the new timeline; anything outside the kept window is dropped.")
+                .font(Theme.Font.caption)
+                .foregroundStyle(Theme.Color.textTertiary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(Theme.Color.surfaceElevated, in: RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal, 16)
+    }
+
+    private func rangeChip(label: String, value: Double, set: @escaping () -> Void) -> some View {
+        Button(action: set) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(label)
+                    .font(.system(.caption, design: .rounded, weight: .semibold))
+                    .foregroundStyle(Theme.Color.textSecondary)
+                Text(SpeedFormatter.timestamp(value))
+                    .font(Theme.Font.timestamp)
+                    .foregroundStyle(Theme.Color.textPrimary)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(Theme.Color.surfaceElevated, in: RoundedRectangle(cornerRadius: 8))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func errorState(message: String) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 36, weight: .light))
+                .foregroundStyle(Theme.Color.accent)
+            Text("Couldn't load this clip")
+                .font(Theme.Font.title)
+                .foregroundStyle(Theme.Color.textPrimary)
+            Text(message)
+                .font(Theme.Font.caption)
+                .foregroundStyle(Theme.Color.textSecondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+    }
+
+    // MARK: - Apply
+
+    private var canApply: Bool {
+        preview.duration > 0
+            && trimEnd - trimStart > 0.05
+            && (trimStart > 0.05 || trimEnd < preview.duration - 0.05)
+    }
+
+    private func applyTrim() async {
+        guard let asset = preview.player.currentItem?.asset else {
+            exportError = "Clip isn't ready yet."
+            return
+        }
+        preview.pause()
+        isExporting = true
+        exportError = nil
+        do {
+            let result = try await TrimExportService().export(
+                asset: asset,
+                start: trimStart,
+                end: trimEnd
+            )
+            applyToModel(fileName: result.fileName, newDuration: result.durationSeconds)
+            isExporting = false
+            dismiss()
+        } catch {
+            isExporting = false
+            exportError = error.localizedDescription
+        }
+    }
+
+    private func applyToModel(fileName: String, newDuration: Double) {
+        // Drop the old trimmed file (if this clip was trimmed before) so we
+        // don't leak the previous sandbox file when the new one supersedes it.
+        if let previous = clip.trimmedFileName {
+            TrimStorage.deleteIfExists(name: previous)
+        }
+        clip.trimmedFileName = fileName
+        clip.durationSeconds = newDuration
+
+        // Shift annotations onto the new timeline.
+        let start = trimStart
+        let end = trimEnd
+        clip.firstDownbeatSeconds = clip.firstDownbeatSeconds.flatMap {
+            TrimAnnotationShifter.shiftPoint($0, trimStart: start, trimEnd: end)
+        }
+        clip.setBeatTimes(
+            TrimAnnotationShifter.shiftBeatTimes(clip.beatTimes, trimStart: start, trimEnd: end)
+        )
+
+        for marker in clip.loopMarkers {
+            if let shifted = TrimAnnotationShifter.shiftRange(
+                start: marker.startSeconds,
+                end: marker.endSeconds,
+                trimStart: start,
+                trimEnd: end
+            ) {
+                marker.startSeconds = shifted.start
+                marker.endSeconds = shifted.end
+            } else {
+                modelContext.delete(marker)
+            }
+        }
+
+        for segment in clip.segments {
+            if let shifted = TrimAnnotationShifter.shiftRange(
+                start: segment.startSeconds,
+                end: segment.endSeconds,
+                trimStart: start,
+                trimEnd: end
+            ) {
+                segment.startSeconds = shifted.start
+                segment.endSeconds = shifted.end
+            } else {
+                modelContext.delete(segment)
+            }
+        }
+
+        try? modelContext.save()
+    }
+}
+
+// MARK: - Player surface
+
+private struct TrimPlayerSurface: UIViewRepresentable {
+    let player: AVPlayer
+
+    func makeUIView(context: Context) -> TrimPlayerView {
+        let view = TrimPlayerView()
+        view.playerLayer.player = player
+        view.playerLayer.videoGravity = .resizeAspect
+        return view
+    }
+
+    func updateUIView(_ uiView: TrimPlayerView, context: Context) {
+        uiView.playerLayer.player = player
+    }
+}
+
+private final class TrimPlayerView: UIView {
+    override static var layerClass: AnyClass { AVPlayerLayer.self }
+
+    var playerLayer: AVPlayerLayer {
+        guard let layer = layer as? AVPlayerLayer else {
+            preconditionFailure("TrimPlayerView.layer must be an AVPlayerLayer")
+        }
+        return layer
+    }
+}
+
+// MARK: - Range bar
+
+/// Two draggable handles + a playhead. The playhead is read-only here —
+/// dragging the bar (not a handle) seeks the preview player.
+private struct TrimRangeBar: View {
+
+    let duration: Double
+    let currentTime: Double
+    @Binding var trimStart: Double
+    @Binding var trimEnd: Double
+    let onSeek: (Double) -> Void
+
+    @GestureState private var dragOffset: CGFloat = 0
+    private let handleWidth: CGFloat = 14
+
+    var body: some View {
+        GeometryReader { geo in
+            let width = max(1, geo.size.width)
+            let startX = xFor(time: trimStart, width: width)
+            let endX = xFor(time: trimEnd, width: width)
+            let playX = xFor(time: currentTime, width: width)
+
+            ZStack(alignment: .leading) {
+                // Track.
+                Capsule()
+                    .fill(Theme.Color.surfaceElevated)
+                    .frame(height: 8)
+
+                // Trimmed-out shaded regions.
+                Rectangle()
+                    .fill(Color.black.opacity(0.45))
+                    .frame(width: max(0, startX), height: 30)
+                Rectangle()
+                    .fill(Color.black.opacity(0.45))
+                    .frame(width: max(0, width - endX), height: 30)
+                    .offset(x: endX)
+
+                // Selected window.
+                Capsule()
+                    .fill(Theme.Color.accentSoft)
+                    .frame(width: max(2, endX - startX), height: 12)
+                    .offset(x: startX)
+
+                // Playhead.
+                Rectangle()
+                    .fill(.white)
+                    .frame(width: 2, height: 28)
+                    .offset(x: max(0, playX - 1))
+
+                // Start handle.
+                handleView()
+                    .offset(x: max(0, startX - handleWidth / 2))
+                    .gesture(
+                        DragGesture(minimumDistance: 0)
+                            .onChanged { value in
+                                let t = timeFor(x: value.location.x, width: width)
+                                trimStart = max(0, min(t, trimEnd - 0.05))
+                                onSeek(trimStart)
+                            }
+                    )
+
+                // End handle.
+                handleView()
+                    .offset(x: max(0, endX - handleWidth / 2))
+                    .gesture(
+                        DragGesture(minimumDistance: 0)
+                            .onChanged { value in
+                                let t = timeFor(x: value.location.x, width: width)
+                                trimEnd = min(duration, max(t, trimStart + 0.05))
+                                onSeek(trimEnd)
+                            }
+                    )
+            }
+            .frame(maxHeight: .infinity)
+            .contentShape(Rectangle())
+        }
+        .frame(height: 36)
+        .padding(.horizontal, 16)
+    }
+
+    private func xFor(time: Double, width: CGFloat) -> CGFloat {
+        guard duration > 0 else { return 0 }
+        return CGFloat(min(1, max(0, time / duration))) * width
+    }
+
+    private func timeFor(x: CGFloat, width: CGFloat) -> Double {
+        let ratio = Double(min(width, max(0, x)) / width)
+        return ratio * duration
+    }
+
+    private func handleView() -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 3)
+                .fill(Theme.Color.accent)
+                .frame(width: handleWidth, height: 30)
+            RoundedRectangle(cornerRadius: 1)
+                .fill(.black.opacity(0.4))
+                .frame(width: 2, height: 14)
+        }
+    }
+}

--- a/StepBack/Views/TrimView.swift
+++ b/StepBack/Views/TrimView.swift
@@ -4,32 +4,37 @@ import SwiftData
 import SwiftUI
 import UIKit
 
-/// Modal trim editor. Plays the clip muted in a loop within the chosen
-/// [start, end] window so the user can audition the trim, then exports
-/// the range to the sandbox and rebases all annotations on the new
-/// timeline.
+/// Modal trim editor. Shares the parent practice screen's `AVPlayer` so we
+/// don't double the in-memory video buffers — long clips on a phone will
+/// blow past the per-process limit fast if two players are decoding the
+/// same source.
+///
+/// Picks a [start, end] window with two handles, then exports the range
+/// to the sandbox and rebases all annotations on the new timeline.
 struct TrimView: View {
 
     let clip: DanceClip
+    let player: AVPlayer
+    let initialDuration: Double
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
 
-    @StateObject private var preview: PracticePlayerViewModel
+    @State private var duration: Double
+    @State private var currentTime: Double = 0
+    @State private var isPlaying: Bool = false
     @State private var trimStart: Double = 0
-    @State private var trimEnd: Double = 0
+    @State private var trimEnd: Double
     @State private var isExporting = false
     @State private var exportError: String?
-    @State private var hasInitializedHandles = false
+    @State private var timeObserver: Any?
 
-    init(clip: DanceClip) {
+    init(clip: DanceClip, player: AVPlayer, initialDuration: Double) {
         self.clip = clip
-        _preview = StateObject(
-            wrappedValue: PracticePlayerViewModel(
-                assetIdentifier: clip.assetIdentifier,
-                localFileURL: clip.trimmedFileURL
-            )
-        )
+        self.player = player
+        self.initialDuration = initialDuration
+        _duration = State(initialValue: initialDuration)
+        _trimEnd = State(initialValue: initialDuration)
     }
 
     var body: some View {
@@ -53,68 +58,51 @@ struct TrimView: View {
                 }
             }
         }
-        .task { await preview.load() }
-        .onChange(of: preview.duration) { _, newDuration in
-            if !hasInitializedHandles, newDuration > 0 {
-                trimStart = 0
-                trimEnd = newDuration
-                hasInitializedHandles = true
-                preview.seek(to: 0)
-            }
+        .onAppear {
+            seek(to: 0)
+            attachTimeObserver()
         }
-        .onChange(of: preview.currentTime) { _, t in
-            // Loop preview within the chosen window.
-            if t >= trimEnd, preview.duration > 0 {
-                preview.seek(to: trimStart)
-            }
-        }
+        .onDisappear { detachTimeObserver() }
         .preferredColorScheme(.dark)
     }
 
     // MARK: - Content
 
-    @ViewBuilder
     private var content: some View {
-        if let error = preview.loadError {
-            errorState(message: error)
-        } else if !preview.isReady {
-            ProgressView().tint(Theme.Color.accent)
-        } else {
-            VStack(spacing: 16) {
-                videoPanel
-                handles
-                preset
-                if let exportError {
-                    Text(exportError)
-                        .font(Theme.Font.caption)
-                        .foregroundStyle(.red.opacity(0.9))
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, 16)
-                }
-                if isExporting {
-                    HStack(spacing: 8) {
-                        ProgressView().tint(Theme.Color.accent)
-                        Text("Exporting…")
-                            .font(Theme.Font.caption)
-                            .foregroundStyle(Theme.Color.textSecondary)
-                    }
-                }
-                Spacer(minLength: 0)
+        VStack(spacing: 16) {
+            videoPanel
+            handles
+            preset
+            if let exportError {
+                Text(exportError)
+                    .font(Theme.Font.caption)
+                    .foregroundStyle(.red.opacity(0.9))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 16)
             }
-            .padding(.top, 8)
+            if isExporting {
+                HStack(spacing: 8) {
+                    ProgressView().tint(Theme.Color.accent)
+                    Text("Exporting…")
+                        .font(Theme.Font.caption)
+                        .foregroundStyle(Theme.Color.textSecondary)
+                }
+            }
+            Spacer(minLength: 0)
         }
+        .padding(.top, 8)
     }
 
     private var videoPanel: some View {
-        TrimPlayerSurface(player: preview.player)
+        TrimPlayerSurface(player: player)
             .aspectRatio(16.0 / 9.0, contentMode: .fit)
             .background(Color.black)
             .overlay(alignment: .bottom) {
                 HStack {
                     Button {
-                        preview.togglePlayPause()
+                        togglePlayPause()
                     } label: {
-                        Image(systemName: preview.isPlaying ? "pause.fill" : "play.fill")
+                        Image(systemName: isPlaying ? "pause.fill" : "play.fill")
                             .font(.system(size: 14, weight: .bold))
                             .foregroundStyle(.black)
                             .frame(width: 36, height: 36)
@@ -122,7 +110,7 @@ struct TrimView: View {
                     }
                     .buttonStyle(.plain)
                     Spacer()
-                    Text("\(SpeedFormatter.timestamp(preview.currentTime)) / \(SpeedFormatter.timestamp(preview.duration))")
+                    Text("\(SpeedFormatter.timestamp(currentTime)) / \(SpeedFormatter.timestamp(duration))")
                         .font(Theme.Font.timestamp)
                         .foregroundStyle(.white)
                         .padding(.horizontal, 8)
@@ -136,20 +124,20 @@ struct TrimView: View {
     private var handles: some View {
         VStack(spacing: 10) {
             TrimRangeBar(
-                duration: max(preview.duration, 0.001),
-                currentTime: preview.currentTime,
+                duration: max(duration, 0.001),
+                currentTime: currentTime,
                 trimStart: $trimStart,
                 trimEnd: $trimEnd,
-                onSeek: { preview.seek(to: $0) }
+                onSeek: { seek(to: $0) }
             )
             HStack {
                 rangeChip(
                     label: "Start",
                     value: trimStart,
                     set: {
-                        trimStart = preview.currentTime
+                        trimStart = currentTime
                         if trimEnd <= trimStart + 0.05 {
-                            trimEnd = min(preview.duration, trimStart + 0.5)
+                            trimEnd = min(duration, trimStart + 0.5)
                         }
                     }
                 )
@@ -162,7 +150,7 @@ struct TrimView: View {
                     label: "End",
                     value: trimEnd,
                     set: {
-                        trimEnd = preview.currentTime
+                        trimEnd = currentTime
                         if trimStart >= trimEnd - 0.05 {
                             trimStart = max(0, trimEnd - 0.5)
                         }
@@ -179,7 +167,7 @@ struct TrimView: View {
             Text("Heads up")
                 .font(.system(.footnote, design: .rounded, weight: .semibold))
                 .foregroundStyle(Theme.Color.textSecondary)
-            Text("Trimming replaces the clip's source with a new file. Patterns, loops, and beat times are kept and shifted to the new timeline; anything outside the kept window is dropped.")
+            Text("Trimming replaces the clip's source with a new file. Patterns and beat times are kept and shifted to the new timeline; anything outside the kept window is dropped.")
                 .font(Theme.Font.caption)
                 .foregroundStyle(Theme.Color.textTertiary)
         }
@@ -206,36 +194,61 @@ struct TrimView: View {
         .buttonStyle(.plain)
     }
 
-    private func errorState(message: String) -> some View {
-        VStack(spacing: 12) {
-            Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: 36, weight: .light))
-                .foregroundStyle(Theme.Color.accent)
-            Text("Couldn't load this clip")
-                .font(Theme.Font.title)
-                .foregroundStyle(Theme.Color.textPrimary)
-            Text(message)
-                .font(Theme.Font.caption)
-                .foregroundStyle(Theme.Color.textSecondary)
-                .multilineTextAlignment(.center)
+    // MARK: - Transport
+
+    private func togglePlayPause() {
+        if isPlaying {
+            player.pause()
+            isPlaying = false
+        } else {
+            player.play()
+            isPlaying = true
         }
-        .padding()
+    }
+
+    private func seek(to seconds: Double) {
+        let clamped = max(0, min(seconds, duration))
+        let time = CMTime(seconds: clamped, preferredTimescale: 600)
+        player.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero)
+        currentTime = clamped
+    }
+
+    private func attachTimeObserver() {
+        let interval = CMTime(seconds: 0.1, preferredTimescale: 600)
+        timeObserver = player.addPeriodicTimeObserver(forInterval: interval, queue: .main) { time in
+            let seconds = time.seconds
+            guard seconds.isFinite else { return }
+            currentTime = max(0, min(seconds, duration))
+            isPlaying = player.rate > 0
+            if seconds >= trimEnd, duration > 0 {
+                player.seek(to: CMTime(seconds: trimStart, preferredTimescale: 600), toleranceBefore: .zero, toleranceAfter: .zero)
+            }
+        }
+    }
+
+    private func detachTimeObserver() {
+        if let timeObserver {
+            player.removeTimeObserver(timeObserver)
+        }
+        timeObserver = nil
+        player.pause()
     }
 
     // MARK: - Apply
 
     private var canApply: Bool {
-        preview.duration > 0
+        duration > 0
             && trimEnd - trimStart > 0.05
-            && (trimStart > 0.05 || trimEnd < preview.duration - 0.05)
+            && (trimStart > 0.05 || trimEnd < duration - 0.05)
     }
 
     private func applyTrim() async {
-        guard let asset = preview.player.currentItem?.asset else {
+        guard let asset = player.currentItem?.asset else {
             exportError = "Clip isn't ready yet."
             return
         }
-        preview.pause()
+        player.pause()
+        isPlaying = false
         isExporting = true
         exportError = nil
         do {
@@ -254,15 +267,12 @@ struct TrimView: View {
     }
 
     private func applyToModel(fileName: String, newDuration: Double) {
-        // Drop the old trimmed file (if this clip was trimmed before) so we
-        // don't leak the previous sandbox file when the new one supersedes it.
         if let previous = clip.trimmedFileName {
             TrimStorage.deleteIfExists(name: previous)
         }
         clip.trimmedFileName = fileName
         clip.durationSeconds = newDuration
 
-        // Shift annotations onto the new timeline.
         let start = trimStart
         let end = trimEnd
         clip.firstDownbeatSeconds = clip.firstDownbeatSeconds.flatMap {
@@ -341,12 +351,10 @@ private struct TrimRangeBar: View {
             let playX = xFor(time: currentTime, width: width)
 
             ZStack(alignment: .leading) {
-                // Track.
                 Capsule()
                     .fill(Theme.Color.surfaceElevated)
                     .frame(height: 8)
 
-                // Trimmed-out shaded regions.
                 Rectangle()
                     .fill(Color.black.opacity(0.45))
                     .frame(width: max(0, startX), height: 30)
@@ -355,19 +363,16 @@ private struct TrimRangeBar: View {
                     .frame(width: max(0, width - endX), height: 30)
                     .offset(x: endX)
 
-                // Selected window.
                 Capsule()
                     .fill(Theme.Color.accentSoft)
                     .frame(width: max(2, endX - startX), height: 12)
                     .offset(x: startX)
 
-                // Playhead.
                 Rectangle()
                     .fill(.white)
                     .frame(width: 2, height: 28)
                     .offset(x: max(0, playX - 1))
 
-                // Start handle.
                 handleView()
                     .offset(x: max(0, startX - handleWidth / 2))
                     .gesture(
@@ -379,7 +384,6 @@ private struct TrimRangeBar: View {
                             }
                     )
 
-                // End handle.
                 handleView()
                     .offset(x: max(0, endX - handleWidth / 2))
                     .gesture(

--- a/StepBackTests/ModelsTests.swift
+++ b/StepBackTests/ModelsTests.swift
@@ -11,7 +11,7 @@ final class ModelsTests: XCTestCase {
     override func setUp() async throws {
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         container = try ModelContainer(
-            for: DanceClip.self, Tag.self, LoopMarker.self,
+            for: DanceClip.self, Tag.self, ClipSegment.self,
             configurations: config
         )
     }
@@ -33,8 +33,9 @@ final class ModelsTests: XCTestCase {
         XCTAssertNil(clip.eventName)
         XCTAssertNil(clip.thumbnailData)
         XCTAssertEqual(clip.durationSeconds, 0)
-        XCTAssertTrue(clip.loopMarkers.isEmpty)
+        XCTAssertTrue(clip.segments.isEmpty)
         XCTAssertTrue(clip.tags.isEmpty)
+        XCTAssertNil(clip.trimmedFileName)
 
         // Beat analysis defaults
         XCTAssertNil(clip.bpm)
@@ -75,35 +76,35 @@ final class ModelsTests: XCTestCase {
         XCTAssertEqual(clip.beatTimes, [])
     }
 
-    // MARK: - LoopMarker
+    // MARK: - ClipSegment
 
-    func testLoopMarkerRelationshipAndCascadeDelete() throws {
+    func testClipSegmentRelationshipAndCascadeDelete() throws {
         let clip = DanceClip(title: "Practice", assetIdentifier: "ASSET-2")
-        let marker = LoopMarker(
-            label: "Hard 8-count",
+        let segment = ClipSegment(
+            title: "Basic step",
             startSeconds: 10,
             endSeconds: 18,
             preferredSpeed: 0.5,
             clip: clip
         )
-        clip.loopMarkers.append(marker)
+        clip.segments.append(segment)
         context.insert(clip)
         try context.save()
 
-        XCTAssertEqual(clip.loopMarkers.count, 1)
-        XCTAssertIdentical(marker.clip, clip)
-        XCTAssertEqual(marker.durationSeconds, 8, accuracy: 0.0001)
+        XCTAssertEqual(clip.segments.count, 1)
+        XCTAssertIdentical(segment.clip, clip)
+        XCTAssertEqual(segment.durationSeconds, 8, accuracy: 0.0001)
 
         context.delete(clip)
         try context.save()
 
-        let remaining = try context.fetch(FetchDescriptor<LoopMarker>())
-        XCTAssertTrue(remaining.isEmpty, "Deleting the clip should cascade to its markers")
+        let remaining = try context.fetch(FetchDescriptor<ClipSegment>())
+        XCTAssertTrue(remaining.isEmpty, "Deleting the clip should cascade to its segments")
     }
 
-    func testLoopMarkerDurationNeverNegative() {
-        let marker = LoopMarker(label: "Weird", startSeconds: 10, endSeconds: 5)
-        XCTAssertEqual(marker.durationSeconds, 0)
+    func testClipSegmentDurationNeverNegative() {
+        let segment = ClipSegment(title: "Weird", startSeconds: 10, endSeconds: 5)
+        XCTAssertEqual(segment.durationSeconds, 0)
     }
 
     // MARK: - Tag

--- a/StepBackTests/TrimAnnotationShifterTests.swift
+++ b/StepBackTests/TrimAnnotationShifterTests.swift
@@ -1,0 +1,94 @@
+@testable import StepBack
+import XCTest
+
+final class TrimAnnotationShifterTests: XCTestCase {
+
+    // MARK: - Points
+
+    func testShiftPointInsideRangeRebases() {
+        XCTAssertEqual(
+            TrimAnnotationShifter.shiftPoint(7, trimStart: 5, trimEnd: 12),
+            2
+        )
+    }
+
+    func testShiftPointOutsideRangeIsDropped() {
+        XCTAssertNil(TrimAnnotationShifter.shiftPoint(2, trimStart: 5, trimEnd: 12))
+        XCTAssertNil(TrimAnnotationShifter.shiftPoint(15, trimStart: 5, trimEnd: 12))
+    }
+
+    func testShiftPointAtBoundariesKeptAndZeroed() {
+        XCTAssertEqual(TrimAnnotationShifter.shiftPoint(5, trimStart: 5, trimEnd: 12), 0)
+        XCTAssertEqual(TrimAnnotationShifter.shiftPoint(12, trimStart: 5, trimEnd: 12), 7)
+    }
+
+    // MARK: - Ranges
+
+    func testShiftRangeFullyInsideRebasesWithoutClamping() {
+        let result = TrimAnnotationShifter.shiftRange(
+            start: 6, end: 10, trimStart: 5, trimEnd: 12
+        )
+        XCTAssertEqual(result, .init(start: 1, end: 5))
+    }
+
+    func testShiftRangeFullyOutsideIsDropped() {
+        XCTAssertNil(
+            TrimAnnotationShifter.shiftRange(
+                start: 1, end: 4, trimStart: 5, trimEnd: 12
+            )
+        )
+        XCTAssertNil(
+            TrimAnnotationShifter.shiftRange(
+                start: 13, end: 18, trimStart: 5, trimEnd: 12
+            )
+        )
+    }
+
+    func testShiftRangeStraddlingStartIsClamped() {
+        let result = TrimAnnotationShifter.shiftRange(
+            start: 3, end: 8, trimStart: 5, trimEnd: 12
+        )
+        XCTAssertEqual(result, .init(start: 0, end: 3))
+    }
+
+    func testShiftRangeStraddlingEndIsClamped() {
+        let result = TrimAnnotationShifter.shiftRange(
+            start: 9, end: 15, trimStart: 5, trimEnd: 12
+        )
+        XCTAssertEqual(result, .init(start: 4, end: 7))
+    }
+
+    func testShiftRangeCollapsingBelowMinimumIsDropped() {
+        // Pre-trim range [4.99, 5.0]: only the last 0.01s overlaps the kept
+        // window — too small to keep as a meaningful segment.
+        XCTAssertNil(
+            TrimAnnotationShifter.shiftRange(
+                start: 4.99, end: 5.0, trimStart: 5, trimEnd: 12
+            )
+        )
+    }
+
+    func testShiftRangeWithInvertedInputReturnsNil() {
+        XCTAssertNil(
+            TrimAnnotationShifter.shiftRange(
+                start: 8, end: 6, trimStart: 5, trimEnd: 12
+            )
+        )
+    }
+
+    // MARK: - Beat times
+
+    func testShiftBeatTimesDropsOutOfWindowAndRebases() {
+        let original: [Double] = [0.5, 2.0, 5.0, 6.5, 9.0, 13.0]
+        let shifted = TrimAnnotationShifter.shiftBeatTimes(
+            original, trimStart: 2, trimEnd: 10
+        )
+        XCTAssertEqual(shifted, [0.0, 3.0, 4.5, 7.0])
+    }
+
+    func testShiftBeatTimesEmptyArrayReturnsEmpty() {
+        XCTAssertTrue(
+            TrimAnnotationShifter.shiftBeatTimes([], trimStart: 0, trimEnd: 1).isEmpty
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Lets you cut a clip down to just the part you care about — drag two handles to pick a start/end, tap Apply, and the clip's source is replaced with a fast passthrough export of the chosen range. **Patterns, loop markers, beat times, and the downbeat anchor are kept and shifted onto the new timeline** so a leading-trim doesn't blow away the work you've already done.

- **`crop` toolbar button** in the practice screen opens a full-screen `TrimView`. Inside: a 16:9 preview that loops within the currently-selected range, two draggable handles on a timeline with shaded "trimmed-out" regions, plus quick "Set start / end from current position" chips.
- **`AVAssetExportSession` passthrough preset** writes a new `.mov` into `Documents/Trims/<uuid>.mov`. No re-encode → fast, no quality loss. Old trimmed file (if re-trimming) is deleted so we don't leak sandbox storage.
- **`DanceClip.trimmedFileName`** is the source-of-truth pointer; when set, playback resolves to the local file instead of the PHAsset (so the trim survives even if the user later deletes the original from Photos).
- **`TrimAnnotationShifter`** is pure shift logic — points dropped if outside, ranges clamped to the new edges, sub-50ms slivers discarded. 10 unit tests (75/75 passing total).
- **`PracticePlayerViewModel.reloadAsset(localFileURL:)`** swaps the underlying source in place after a trim so the player rebinds without popping back to the library.

Stacked on top of `feat/clip-segments` (#39) — that branch needs to land first or this PR shows the segment work too. Easy to flip the base to `main` once #39 is merged.

## Test plan

- [ ] Open a long clip → tap the **crop** button → preview loads, handles default to full range.
- [ ] Drag handles in → preview loops within that window. Scrub to a point, tap **Set Start** / **Set End** chips → handles snap to it.
- [ ] **Apply** → spinner, then the trim view dismisses. Practice screen now shows the trimmed clip; duration label is the new shorter duration; the playhead is at 0.
- [ ] Save a Pattern, set up an A/B Loop, run beat detection — then trim again removing 2s from the start. Confirm:
  - Pattern's start/end shifted by 2s; if it was inside the trimmed-away region, it's gone.
  - Loop marker shifted same way.
  - Beat ticks repositioned correctly; downbeat anchor still aligns.
- [ ] Trim a 2nd time — old trimmed file isn't left behind in the sandbox (`Documents/Trims/` should only have the latest).
- [ ] Cancel a trim mid-session → original clip plays back unchanged.
- [ ] Try to trim the entire clip out (handles inverted) → Apply stays disabled.
- [ ] Delete the original from Photos after a trim → playback still works (file is local).

## Out of scope (future)

- Multiple trims as separate clips (current model is destructive single-source).
- Re-encoding to shrink file size or change format.
- Trim presets ("trim 2s from start", "trim to first beat").
