### PR TITLE
Fix Library grid overflow when thumbnails are portrait

### DIFF
--- a/StepBack/Views/LibraryView.swift
+++ b/StepBack/Views/LibraryView.swift
@@ -431,6 +431,7 @@ private struct LibraryCell: View {
                 }
                 .padding(6)
             }
+            .frame(maxWidth: .infinity)
             .frame(height: 180)
             .clipShape(RoundedRectangle(cornerRadius: Theme.Metrics.cornerRadius))
             .overlay(
@@ -455,6 +456,8 @@ private struct LibraryCell: View {
             Image(uiImage: uiImage)
                 .resizable()
                 .scaledToFill()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .clipped()
         } else {
             Image(systemName: "film")
                 .font(.system(size: 28, weight: .light))


### PR DESCRIPTION
## Summary

Fixes the busted Library grid where portrait-aspect thumbnails were pushing cells past their `GridItem` column and visually overlapping the next column / clipping the title labels off the left edge.

**Root cause:** the cell uses `Image(uiImage:).resizable().scaledToFill()` with no width constraint. `scaledToFill` lets the image keep its natural aspect ratio, and for a tall portrait the natural-size width can exceed the grid column slot — that expanded the enclosing `ZStack` and bled into the next column.

**Fix:** `maxWidth: .infinity` on the ZStack to clamp it to the column's allocated width, plus `maxWidth: .infinity, maxHeight: .infinity` and `.clipped()` on the image so any overflow is just cropped.

## Test plan

- [ ] Pull the branch, run the app — Library grid renders cleanly with two equal columns and no horizontal overflow.
- [ ] Mix of portrait and landscape source videos → all cells stay inside their column; thumbnails are cropped (not stretched).
- [ ] Selection mode and ••• menu still work.
