### PR TITLE
Use a unique bundle id so signing succeeds

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -471,7 +471,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.stepback.app.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sauravpanda.stepback.tests;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StepBack.app/StepBack";
@@ -492,7 +492,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.stepback.app;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sauravpanda.stepback;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -512,7 +512,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.stepback.app;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sauravpanda.stepback;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -529,7 +529,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.stepback.app.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sauravpanda.stepback.tests;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StepBack.app/StepBack";

--- a/project.yml
+++ b/project.yml
@@ -1,6 +1,6 @@
 name: StepBack
 options:
-  bundleIdPrefix: com.stepback
+  bundleIdPrefix: com.sauravpanda.stepback
   deploymentTarget:
     iOS: "17.0"
   createIntermediateGroups: true
@@ -48,7 +48,7 @@ targets:
           - UIInterfaceOrientationLandscapeRight
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.stepback.app
+        PRODUCT_BUNDLE_IDENTIFIER: com.sauravpanda.stepback
         TARGETED_DEVICE_FAMILY: "1,2"
         CODE_SIGN_STYLE: Automatic
         CURRENT_PROJECT_VERSION: 1
@@ -67,7 +67,7 @@ targets:
       - target: StepBack
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.stepback.app.tests
+        PRODUCT_BUNDLE_IDENTIFIER: com.sauravpanda.stepback.tests
         GENERATE_INFOPLIST_FILE: YES
 
 schemes:


### PR DESCRIPTION
Apple rejected `com.stepback.app` — it's registered to a different team. Switching to `com.sauravpanda.stepback` (and `.tests` for the test target) so automatic signing works.