### PR TITLE
Keep the screen awake while practicing (#43)

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		5F405BD1B2F2EB7F30970683 /* LibraryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */; };
 		622A6663058E88A57B465B62 /* StepTiming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0265ABC8E91AF4657EB95F83 /* StepTiming.swift */; };
 		691A3AE86C110C252A1412FE /* BeatGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078CB839E392E788201DD665 /* BeatGrid.swift */; };
+		72A012D3DCF8FA13D69C1868 /* KeepScreenAwake.swift in Sources */ = {isa = PBXBuildFile; fileRef = E56B6CE778D3BD0C5B1B248B /* KeepScreenAwake.swift */; };
 		76D520F6EC5A0A8E57C8AAA1 /* BeatDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6BC077A9FA8B51D07C178A0 /* BeatDetectorTests.swift */; };
 		7FA3BBA0113FDF3282819E84 /* PracticePlayerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */; };
 		9DCAAD9B2DCFAEE83A9D4879 /* TrimView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF9D9B68E730BA51C86D70A /* TrimView.swift */; };
@@ -84,6 +85,7 @@
 		CC6BAE20433D2ED45F00AD41 /* PracticeBeatUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeBeatUI.swift; sourceTree = "<group>"; };
 		D8F8476EAB523378C1F1E046 /* PhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosService.swift; sourceTree = "<group>"; };
 		DB3B8C1BB7ACE2D1C13C7200 /* StepTimingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepTimingTests.swift; sourceTree = "<group>"; };
+		E56B6CE778D3BD0C5B1B248B /* KeepScreenAwake.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeepScreenAwake.swift; sourceTree = "<group>"; };
 		EAF9D9B68E730BA51C86D70A /* TrimView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimView.swift; sourceTree = "<group>"; };
 		EB991AFC28C64366954E1D19 /* TrimAnnotationShifterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimAnnotationShifterTests.swift; sourceTree = "<group>"; };
 		F6BC077A9FA8B51D07C178A0 /* BeatDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeatDetectorTests.swift; sourceTree = "<group>"; };
@@ -93,6 +95,7 @@
 		0CCE7D9CB9AEFC2FA82B2EFD /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				E56B6CE778D3BD0C5B1B248B /* KeepScreenAwake.swift */,
 				2D07843122196F5F0DA539D1 /* Theme.swift */,
 			);
 			path = Utilities;
@@ -288,6 +291,7 @@
 				691A3AE86C110C252A1412FE /* BeatGrid.swift in Sources */,
 				1D0BE1897582A939153E6CE8 /* ClipEditView.swift in Sources */,
 				B6CB4CFDF1EB16757B0D78AA /* CompareView.swift in Sources */,
+				72A012D3DCF8FA13D69C1868 /* KeepScreenAwake.swift in Sources */,
 				A88000A1ACD9503F7A9D6143 /* LibraryView.swift in Sources */,
 				1F02ADF6471B01E48A824A49 /* Models.swift in Sources */,
 				F7AD3FACE8B875F1C9DFA310 /* PhotosService.swift in Sources */,

--- a/StepBack/Utilities/KeepScreenAwake.swift
+++ b/StepBack/Utilities/KeepScreenAwake.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+import UIKit
+
+/// Disables the system idle timer while the modified view is on screen.
+///
+/// Apply to any practice surface (PracticeView, CompareView, TrimView) so a
+/// phone parked on a studio stand doesn't sleep mid-loop. Each view manages
+/// its own toggle: when SwiftUI swaps between them via push/cover, the
+/// outgoing view's onDisappear briefly re-enables the timer and the incoming
+/// view's onAppear immediately disables it again — net effect is "always
+/// disabled while a practice surface is visible."
+struct KeepScreenAwakeModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .onAppear { UIApplication.shared.isIdleTimerDisabled = true }
+            .onDisappear { UIApplication.shared.isIdleTimerDisabled = false }
+    }
+}
+
+extension View {
+    func keepScreenAwake() -> some View {
+        modifier(KeepScreenAwakeModifier())
+    }
+}

--- a/StepBack/Views/CompareView.swift
+++ b/StepBack/Views/CompareView.swift
@@ -68,6 +68,7 @@ struct CompareView: View {
             primary.pause()
             secondary.pause()
         }
+        .keepScreenAwake()
     }
 
     // MARK: - Panels

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -79,6 +79,7 @@ struct PracticeView: View {
             }
         }
         .task { await vm.load() }
+        .keepScreenAwake()
         .sheet(isPresented: $comparePickerPresented) {
             CompareClipPicker(excludedID: clip.id) { picked in
                 compareSecondary = picked

--- a/StepBack/Views/TrimView.swift
+++ b/StepBack/Views/TrimView.swift
@@ -63,6 +63,7 @@ struct TrimView: View {
             attachTimeObserver()
         }
         .onDisappear { detachTimeObserver() }
+        .keepScreenAwake()
         .preferredColorScheme(.dark)
     }
 


### PR DESCRIPTION
Closes #43.

Adds a `KeepScreenAwakeModifier` that toggles `UIApplication.shared.isIdleTimerDisabled` on `onAppear`/`onDisappear`, applied to PracticeView, CompareView, and TrimView. Phone parked on a studio stand no longer sleeps mid-loop.