### PR TITLE
Generate per-segment thumbnail frame (#44)

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		A49A15759EECD46EC5E3A694 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D07843122196F5F0DA539D1 /* Theme.swift */; };
 		A88000A1ACD9503F7A9D6143 /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB30650146433E889DC2AF4 /* LibraryView.swift */; };
 		AB9467B4E5F44BFF1AA916B1 /* TrimAnnotationShifterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB991AFC28C64366954E1D19 /* TrimAnnotationShifterTests.swift */; };
+		AD47C4CE36AF1FD4FF011BCC /* SegmentThumbnailGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94AAA488969D7CF77497859D /* SegmentThumbnailGenerator.swift */; };
 		B3A98425CA93181D0723AB60 /* AutoTagServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C54B956DF5DE01C00D95680 /* AutoTagServiceTests.swift */; };
 		B6CB4CFDF1EB16757B0D78AA /* CompareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D24FDCCE45AEFB352C5EBF /* CompareView.swift */; };
 		BE33E08127A1601493FB7837 /* LoopEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57317F752B65258CB2D04530 /* LoopEvaluatorTests.swift */; };
@@ -74,6 +75,7 @@
 		8D25E6771271EDD5B867F61E /* ClipEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipEditView.swift; sourceTree = "<group>"; };
 		90115F7F368CDD3B0832B3B3 /* Generated-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Generated-Info.plist"; sourceTree = "<group>"; };
 		92D24FDCCE45AEFB352C5EBF /* CompareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompareView.swift; sourceTree = "<group>"; };
+		94AAA488969D7CF77497859D /* SegmentThumbnailGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentThumbnailGenerator.swift; sourceTree = "<group>"; };
 		99CA1B5B91B8D4637FEEF872 /* AutoTagService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoTagService.swift; sourceTree = "<group>"; };
 		A3776C829FB11907CC7E87F9 /* StepBack.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = StepBack.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AAB30650146433E889DC2AF4 /* LibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryView.swift; sourceTree = "<group>"; };
@@ -151,6 +153,7 @@
 				078CB839E392E788201DD665 /* BeatGrid.swift */,
 				D8F8476EAB523378C1F1E046 /* PhotosService.swift */,
 				543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */,
+				94AAA488969D7CF77497859D /* SegmentThumbnailGenerator.swift */,
 				0265ABC8E91AF4657EB95F83 /* StepTiming.swift */,
 				71643D36F7F8D028B560F012 /* TrimAnnotationShifter.swift */,
 				6BCED6C8E1CE7A48B341C8B1 /* TrimExportService.swift */,
@@ -300,6 +303,7 @@
 				7FA3BBA0113FDF3282819E84 /* PracticePlayerViewModel.swift in Sources */,
 				527B9B596B00D2C774173ECA /* PracticeView.swift in Sources */,
 				9F90D5641396A9BF3E7A09FE /* RootView.swift in Sources */,
+				AD47C4CE36AF1FD4FF011BCC /* SegmentThumbnailGenerator.swift in Sources */,
 				1EC09265A1CD5B1E67415B39 /* StepBackApp.swift in Sources */,
 				622A6663058E88A57B465B62 /* StepTiming.swift in Sources */,
 				A49A15759EECD46EC5E3A694 /* Theme.swift in Sources */,

--- a/StepBack/Models/Models.swift
+++ b/StepBack/Models/Models.swift
@@ -111,6 +111,7 @@ final class ClipSegment: Equatable, Hashable {
     var notes: String
     var dateAdded: Date
     var orderIndex: Int
+    var thumbnailData: Data?
     var clip: DanceClip?
 
     init(

--- a/StepBack/Services/SegmentThumbnailGenerator.swift
+++ b/StepBack/Services/SegmentThumbnailGenerator.swift
@@ -1,0 +1,32 @@
+import AVFoundation
+import CoreGraphics
+import Foundation
+import UIKit
+
+/// Generates a single-frame JPEG thumbnail for a `ClipSegment` from its parent
+/// asset. Pulled from `startSeconds + 0.1` to skip the cut-in frame which is
+/// often a dark transition or the wrong gesture.
+enum SegmentThumbnailGenerator {
+
+    static func generate(
+        from asset: AVAsset,
+        atSeconds seconds: Double,
+        size: CGSize = CGSize(width: 200, height: 200),
+        quality: CGFloat = 0.6
+    ) async -> Data? {
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        generator.maximumSize = size
+        generator.requestedTimeToleranceBefore = CMTime(seconds: 0.1, preferredTimescale: 600)
+        generator.requestedTimeToleranceAfter = CMTime(seconds: 0.1, preferredTimescale: 600)
+
+        let target = CMTime(seconds: max(0, seconds + 0.1), preferredTimescale: 600)
+
+        do {
+            let (cgImage, _) = try await generator.image(at: target)
+            return UIImage(cgImage: cgImage).jpegData(compressionQuality: quality)
+        } catch {
+            return nil
+        }
+    }
+}

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -316,6 +316,24 @@ extension PracticeView {
         )
         modelContext.insert(segment)
         try? modelContext.save()
+
+        // Render the thumbnail off-actor; persist back when ready.
+        if let asset = vm.player.currentItem?.asset {
+            let segmentID = segment.id
+            let startSeconds = start
+            Task {
+                let data = await SegmentThumbnailGenerator.generate(
+                    from: asset,
+                    atSeconds: startSeconds
+                )
+                await MainActor.run {
+                    if let stored = clip.segments.first(where: { $0.id == segmentID }) {
+                        stored.thumbnailData = data
+                        try? modelContext.save()
+                    }
+                }
+            }
+        }
     }
 
     fileprivate func deleteSegment(_ segment: ClipSegment) {
@@ -552,13 +570,7 @@ private struct SegmentCard: View {
     var body: some View {
         Button(action: onPlay) {
             HStack(spacing: 10) {
-                Image(systemName: isActive ? "waveform" : "play.fill")
-                    .font(.system(size: 14, weight: .bold))
-                    .foregroundStyle(isActive ? .black : Theme.Color.accent)
-                    .frame(width: 28, height: 28)
-                    .background(
-                        Circle().fill(isActive ? Theme.Color.accent : Theme.Color.accentSoft)
-                    )
+                segmentGlyph
                 VStack(alignment: .leading, spacing: 2) {
                     Text(segment.title)
                         .font(.system(.footnote, design: .rounded, weight: .semibold))
@@ -595,6 +607,40 @@ private struct SegmentCard: View {
             } label: {
                 Label("Rename", systemImage: "pencil")
             }
+        }
+    }
+
+    @ViewBuilder
+    private var segmentGlyph: some View {
+        if let data = segment.thumbnailData, let uiImage = UIImage(data: data) {
+            ZStack {
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 36, height: 36)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                if isActive {
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Theme.Color.accent.opacity(0.4))
+                        .frame(width: 36, height: 36)
+                    Image(systemName: "waveform")
+                        .font(.system(size: 14, weight: .bold))
+                        .foregroundStyle(.black)
+                }
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(isActive ? Theme.Color.accent : Color.clear, lineWidth: 1.5)
+            )
+        } else {
+            Image(systemName: isActive ? "waveform" : "play.fill")
+                .font(.system(size: 14, weight: .bold))
+                .foregroundStyle(isActive ? .black : Theme.Color.accent)
+                .frame(width: 36, height: 36)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(isActive ? Theme.Color.accent : Theme.Color.accentSoft)
+                )
         }
     }
 }


### PR DESCRIPTION
Closes #44.

ClipSegment now carries a 200x200 JPEG thumbnail pulled from the parent asset at startSeconds + 0.1 (skip the cut-in frame). Generation runs off-actor right after the segment is persisted; a UUID lookup writes the result back so we don't hold a ClipSegment reference across the async hop.

SegmentCard renders the thumbnail with a rounded corner instead of the generic play icon, and overlays an accent tint + waveform glyph when the pattern is the active loop.