### PR TITLE
Lock screen / Now Playing controls via MediaPlayer (#45)

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		1EC09265A1CD5B1E67415B39 /* StepBackApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023608F63978F9D1668F5AFC /* StepBackApp.swift */; };
 		1F02ADF6471B01E48A824A49 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6745FF48B10D28A5ED4BB568 /* Models.swift */; };
 		2B90619AE0B5262B774DEAC1 /* PracticeControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35987D9825155E131A40950 /* PracticeControls.swift */; };
+		3D990657ED52C04DBB04687A /* NowPlayingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46242480BEBB0CDD9B45F158 /* NowPlayingController.swift */; };
 		4181110140BD581DBFB0A380 /* StepTimingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3B8C1BB7ACE2D1C13C7200 /* StepTimingTests.swift */; };
 		527B9B596B00D2C774173ECA /* PracticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35AE6C8D6564306E1B0ADA20 /* PracticeView.swift */; };
 		5F405BD1B2F2EB7F30970683 /* LibraryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */; };
@@ -61,6 +62,7 @@
 		16E676751B59ED083837CE39 /* SpeedFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedFormatterTests.swift; sourceTree = "<group>"; };
 		2D07843122196F5F0DA539D1 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		35AE6C8D6564306E1B0ADA20 /* PracticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeView.swift; sourceTree = "<group>"; };
+		46242480BEBB0CDD9B45F158 /* NowPlayingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingController.swift; sourceTree = "<group>"; };
 		462E264B215595E9EC3D1C4A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		46ED8A21F9D36A90E3306D55 /* StepBackTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = StepBackTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticePlayerViewModel.swift; sourceTree = "<group>"; };
@@ -151,6 +153,7 @@
 				99CA1B5B91B8D4637FEEF872 /* AutoTagService.swift */,
 				C59BD8F65AE46261EEFD4F69 /* BeatDetector.swift */,
 				078CB839E392E788201DD665 /* BeatGrid.swift */,
+				46242480BEBB0CDD9B45F158 /* NowPlayingController.swift */,
 				D8F8476EAB523378C1F1E046 /* PhotosService.swift */,
 				543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */,
 				94AAA488969D7CF77497859D /* SegmentThumbnailGenerator.swift */,
@@ -297,6 +300,7 @@
 				72A012D3DCF8FA13D69C1868 /* KeepScreenAwake.swift in Sources */,
 				A88000A1ACD9503F7A9D6143 /* LibraryView.swift in Sources */,
 				1F02ADF6471B01E48A824A49 /* Models.swift in Sources */,
+				3D990657ED52C04DBB04687A /* NowPlayingController.swift in Sources */,
 				F7AD3FACE8B875F1C9DFA310 /* PhotosService.swift in Sources */,
 				03C973FD27336E9DD2EDE507 /* PracticeBeatUI.swift in Sources */,
 				2B90619AE0B5262B774DEAC1 /* PracticeControls.swift in Sources */,

--- a/StepBack/Services/NowPlayingController.swift
+++ b/StepBack/Services/NowPlayingController.swift
@@ -1,0 +1,123 @@
+import AVFoundation
+import Combine
+import MediaPlayer
+import UIKit
+
+/// Bridges an `AVPlayer` to `MPNowPlayingInfoCenter` and the
+/// `MPRemoteCommandCenter`. Surfaces title + artwork + transport state on
+/// the lock screen and Control Center, and routes Play/Pause/Skip commands
+/// from there back to the player.
+///
+/// Owned by `PracticePlayerViewModel`; `activate()` should be called when
+/// PracticeView appears, `deactivate()` when it disappears.
+@MainActor
+final class NowPlayingController {
+
+    private let player: AVPlayer
+    private weak var clip: DanceClip?
+    private var commandHandlers: [Any] = []
+    private var cancellables: Set<AnyCancellable> = []
+    private var rateObservation: NSKeyValueObservation?
+
+    init(player: AVPlayer, clip: DanceClip) {
+        self.player = player
+        self.clip = clip
+    }
+
+    func activate() {
+        registerCommands()
+        rateObservation = player.observe(\.rate, options: [.new]) { [weak self] _, _ in
+            Task { @MainActor in self?.updateInfo() }
+        }
+        updateInfo()
+    }
+
+    func deactivate() {
+        let center = MPRemoteCommandCenter.shared()
+        center.playCommand.removeTarget(nil)
+        center.pauseCommand.removeTarget(nil)
+        center.togglePlayPauseCommand.removeTarget(nil)
+        center.skipForwardCommand.removeTarget(nil)
+        center.skipBackwardCommand.removeTarget(nil)
+        center.changePlaybackPositionCommand.removeTarget(nil)
+        commandHandlers.removeAll()
+        rateObservation?.invalidate()
+        rateObservation = nil
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+    }
+
+    /// Push the latest state (title, position, rate) to Now Playing.
+    /// Called whenever transport state changes meaningfully.
+    func updateInfo() {
+        guard let clip else { return }
+        var info: [String: Any] = [:]
+        info[MPMediaItemPropertyTitle] = clip.title
+        info[MPMediaItemPropertyArtist] = clip.eventName ?? "StepBack"
+        if let duration = player.currentItem?.duration.seconds, duration.isFinite {
+            info[MPMediaItemPropertyPlaybackDuration] = duration
+        }
+        let elapsed = player.currentTime().seconds
+        if elapsed.isFinite {
+            info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = elapsed
+        }
+        info[MPNowPlayingInfoPropertyPlaybackRate] = Double(player.rate)
+
+        if let data = clip.thumbnailData, let image = UIImage(data: data) {
+            let artwork = MPMediaItemArtwork(boundsSize: image.size) { _ in image }
+            info[MPMediaItemPropertyArtwork] = artwork
+        }
+
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+    }
+
+    // MARK: - Remote commands
+
+    private func registerCommands() {
+        let center = MPRemoteCommandCenter.shared()
+
+        center.playCommand.isEnabled = true
+        center.pauseCommand.isEnabled = true
+        center.togglePlayPauseCommand.isEnabled = true
+        center.skipForwardCommand.isEnabled = true
+        center.skipForwardCommand.preferredIntervals = [1]
+        center.skipBackwardCommand.isEnabled = true
+        center.skipBackwardCommand.preferredIntervals = [1]
+        center.changePlaybackPositionCommand.isEnabled = true
+
+        commandHandlers.append(center.playCommand.addTarget { [weak self] _ in
+            self?.player.play()
+            self?.updateInfo()
+            return .success
+        })
+        commandHandlers.append(center.pauseCommand.addTarget { [weak self] _ in
+            self?.player.pause()
+            self?.updateInfo()
+            return .success
+        })
+        commandHandlers.append(center.togglePlayPauseCommand.addTarget { [weak self] _ in
+            guard let self else { return .commandFailed }
+            if player.rate > 0 { player.pause() } else { player.play() }
+            updateInfo()
+            return .success
+        })
+        commandHandlers.append(center.skipForwardCommand.addTarget { [weak self] _ in
+            self?.player.currentItem?.step(byCount: 1)
+            self?.updateInfo()
+            return .success
+        })
+        commandHandlers.append(center.skipBackwardCommand.addTarget { [weak self] _ in
+            self?.player.currentItem?.step(byCount: -1)
+            self?.updateInfo()
+            return .success
+        })
+        commandHandlers.append(center.changePlaybackPositionCommand.addTarget { [weak self] event in
+            guard let self,
+                  let positionEvent = event as? MPChangePlaybackPositionCommandEvent
+            else { return .commandFailed }
+            let target = CMTime(seconds: positionEvent.positionTime, preferredTimescale: 600)
+            player.seek(to: target, toleranceBefore: .zero, toleranceAfter: .zero)
+            updateInfo()
+            return .success
+        })
+    }
+}

--- a/StepBack/Services/PracticePlayerViewModel.swift
+++ b/StepBack/Services/PracticePlayerViewModel.swift
@@ -34,6 +34,7 @@ final class PracticePlayerViewModel: ObservableObject {
     private let assetIdentifier: String
     private var localFileURL: URL?
     private let photosService: PhotosServicing
+    private var nowPlaying: NowPlayingController?
 
     init(
         assetIdentifier: String,
@@ -52,6 +53,19 @@ final class PracticePlayerViewModel: ObservableObject {
         if let timeObserver {
             player.removeTimeObserver(timeObserver)
         }
+    }
+
+    // MARK: - Now Playing
+
+    func enableNowPlaying(for clip: DanceClip) {
+        let controller = NowPlayingController(player: player, clip: clip)
+        controller.activate()
+        nowPlaying = controller
+    }
+
+    func disableNowPlaying() {
+        nowPlaying?.deactivate()
+        nowPlaying = nil
     }
 
     // MARK: - Loading
@@ -104,11 +118,13 @@ final class PracticePlayerViewModel: ObservableObject {
     func play() {
         player.playImmediately(atRate: Float(speed))
         isPlaying = true
+        nowPlaying?.updateInfo()
     }
 
     func pause() {
         player.pause()
         isPlaying = false
+        nowPlaying?.updateInfo()
     }
 
     func restart() {
@@ -124,6 +140,7 @@ final class PracticePlayerViewModel: ObservableObject {
         let time = CMTime(seconds: clamped, preferredTimescale: 600)
         player.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero)
         currentTime = clamped
+        nowPlaying?.updateInfo()
     }
 
     func setSpeed(_ newSpeed: Double) {

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -79,6 +79,8 @@ struct PracticeView: View {
             }
         }
         .task { await vm.load() }
+        .onAppear { vm.enableNowPlaying(for: clip) }
+        .onDisappear { vm.disableNowPlaying() }
         .keepScreenAwake()
         .sheet(isPresented: $comparePickerPresented) {
             CompareClipPicker(excludedID: clip.id) { picked in


### PR DESCRIPTION
Closes #45.

Bridges the practice AVPlayer to MPNowPlayingInfoCenter + MPRemoteCommandCenter. Control Center, the lock screen, and AirPods can now play/pause, frame-step (skip ±1s mapped to step-by-1-frame), and seek the practice player.

- Title from clip.title, artwork from clip.thumbnailData.
- Elapsed/duration/rate kept in sync via a KVO watch on player.rate plus explicit calls from play/pause/seek.
- NowPlayingController is owned by PracticePlayerViewModel and toggled on PracticeView's onAppear/onDisappear.

**Caveat:** for true lock-screen control (phone screen off), the Background Audio capability (#46) is still needed — without it, locking the phone pauses playback. This PR already gives you Control Center + AirPods control while the app is foregrounded.