### PR TITLE
Background audio + AVPlayerLayer reattach (#46)

### DIFF
--- a/StepBack/Generated-Info.plist
+++ b/StepBack/Generated-Info.plist
@@ -20,14 +20,18 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>StepBack needs access to your videos so you can practice with them.</string>
-	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>StepBack saves ghost-overlay recordings back to your Photos library.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>StepBack uses the camera to record ghost-overlay practice clips.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>StepBack records audio alongside ghost-overlay practice clips.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>StepBack saves ghost-overlay recordings back to your Photos library.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>StepBack needs access to your videos so you can practice with them.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UIColorName</key>

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -394,6 +394,49 @@ private final class PlayerView: UIView {
         }
         return layer
     }
+
+    // Detach the AVPlayer from the layer when backgrounding so iOS keeps
+    // audio flowing even with the Background Audio capability enabled.
+    // While a video output is attached, the system aggressively pauses the
+    // player; nil-ing it lets the audio session keep going. Reattach on
+    // foreground so the user sees frames again.
+    private var stashedPlayer: AVPlayer?
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        if window != nil {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(detachForBackground),
+                name: UIApplication.didEnterBackgroundNotification,
+                object: nil
+            )
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(reattachForForeground),
+                name: UIApplication.willEnterForegroundNotification,
+                object: nil
+            )
+        } else {
+            NotificationCenter.default.removeObserver(self)
+        }
+    }
+
+    @objc private func detachForBackground() {
+        stashedPlayer = playerLayer.player
+        playerLayer.player = nil
+    }
+
+    @objc private func reattachForForeground() {
+        if let stashedPlayer {
+            playerLayer.player = stashedPlayer
+        }
+        stashedPlayer = nil
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
 }
 
 // MARK: - Scrubber

--- a/project.yml
+++ b/project.yml
@@ -35,6 +35,8 @@ targets:
         NSPhotoLibraryAddUsageDescription: "StepBack saves ghost-overlay recordings back to your Photos library."
         NSCameraUsageDescription: "StepBack uses the camera to record ghost-overlay practice clips."
         NSMicrophoneUsageDescription: "StepBack records audio alongside ghost-overlay practice clips."
+        UIBackgroundModes:
+          - audio
         UILaunchScreen:
           UIColorName: LaunchBackground
         UISupportedInterfaceOrientations:
@@ -50,9 +52,6 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.sauravpanda.stepback
         TARGETED_DEVICE_FAMILY: "1,2"
-        CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 1
-        MARKETING_VERSION: "0.1.0"
         CODE_SIGN_STYLE: Automatic
         CURRENT_PROJECT_VERSION: 1
         MARKETING_VERSION: "0.1.0"


### PR DESCRIPTION
Closes #46. Pairs with #45.

- `UIBackgroundModes: [audio]` registered via project.yml so the Background Audio capability is on.
- `AVAudioSession` is already `.playback` (set in StepBackApp).
- **Critical extra:** while an AVPlayerLayer is attached to a player, iOS pauses the player on background even with the capability set. `PlayerView` now nils its layer's player on `didEnterBackground` and restores it on `willEnterForeground` so audio keeps flowing while the phone is locked.
- Bonus: removed a duplicate `CODE_SIGN_STYLE / CURRENT_PROJECT_VERSION / MARKETING_VERSION` block in project.yml.

## Test plan

- [ ] Open a clip → play → lock the phone. Audio keeps playing. Lock-screen Now Playing controls work (play/pause, ±frame, seek).
- [ ] Unlock → video resumes from where audio is, no flash of black frame.
- [ ] AirPods double-tap pauses/resumes.