### PR TITLE
Own video bytes on import (#61)

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		527B9B596B00D2C774173ECA /* PracticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35AE6C8D6564306E1B0ADA20 /* PracticeView.swift */; };
 		5F405BD1B2F2EB7F30970683 /* LibraryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */; };
 		622A6663058E88A57B465B62 /* StepTiming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0265ABC8E91AF4657EB95F83 /* StepTiming.swift */; };
+		648013A1A4C23692CD6ED03B /* OriginalImportServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF4094CC2957462A284F735A /* OriginalImportServiceTests.swift */; };
 		691A3AE86C110C252A1412FE /* BeatGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078CB839E392E788201DD665 /* BeatGrid.swift */; };
 		72A012D3DCF8FA13D69C1868 /* KeepScreenAwake.swift in Sources */ = {isa = PBXBuildFile; fileRef = E56B6CE778D3BD0C5B1B248B /* KeepScreenAwake.swift */; };
 		76D520F6EC5A0A8E57C8AAA1 /* BeatDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6BC077A9FA8B51D07C178A0 /* BeatDetectorTests.swift */; };
@@ -36,6 +37,7 @@
 		C97E59DA25A51E16ECA03607 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C112AEA59633E85CF8267D /* ThemeTests.swift */; };
 		CBA5E26E730D69F9A3E4944B /* TrimAnnotationShifter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71643D36F7F8D028B560F012 /* TrimAnnotationShifter.swift */; };
 		CC6F98E7716925F88449689A /* PhotosServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */; };
+		D8739042EECB4AE2C7804C41 /* OriginalImportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D1395E84111ADD80CC22565 /* OriginalImportService.swift */; };
 		D9873262DD68100D8D3C1021 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 462E264B215595E9EC3D1C4A /* Assets.xcassets */; };
 		DA0EE94353A18DA75824D7A8 /* BeatGridTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7093A077C0A2C139BD7BDD29 /* BeatGridTests.swift */; };
 		E709F2C42DEFD624E08A9C35 /* TrimExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCED6C8E1CE7A48B341C8B1 /* TrimExportService.swift */; };
@@ -65,6 +67,7 @@
 		46242480BEBB0CDD9B45F158 /* NowPlayingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingController.swift; sourceTree = "<group>"; };
 		462E264B215595E9EC3D1C4A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		46ED8A21F9D36A90E3306D55 /* StepBackTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = StepBackTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4D1395E84111ADD80CC22565 /* OriginalImportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OriginalImportService.swift; sourceTree = "<group>"; };
 		543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticePlayerViewModel.swift; sourceTree = "<group>"; };
 		56E94F050959741028A8574D /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		57317F752B65258CB2D04530 /* LoopEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopEvaluatorTests.swift; sourceTree = "<group>"; };
@@ -92,6 +95,7 @@
 		E56B6CE778D3BD0C5B1B248B /* KeepScreenAwake.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeepScreenAwake.swift; sourceTree = "<group>"; };
 		EAF9D9B68E730BA51C86D70A /* TrimView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimView.swift; sourceTree = "<group>"; };
 		EB991AFC28C64366954E1D19 /* TrimAnnotationShifterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimAnnotationShifterTests.swift; sourceTree = "<group>"; };
+		EF4094CC2957462A284F735A /* OriginalImportServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OriginalImportServiceTests.swift; sourceTree = "<group>"; };
 		F6BC077A9FA8B51D07C178A0 /* BeatDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeatDetectorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -138,6 +142,7 @@
 				8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */,
 				57317F752B65258CB2D04530 /* LoopEvaluatorTests.swift */,
 				848D52E156E709AA0226CEE8 /* ModelsTests.swift */,
+				EF4094CC2957462A284F735A /* OriginalImportServiceTests.swift */,
 				B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */,
 				16E676751B59ED083837CE39 /* SpeedFormatterTests.swift */,
 				DB3B8C1BB7ACE2D1C13C7200 /* StepTimingTests.swift */,
@@ -154,6 +159,7 @@
 				C59BD8F65AE46261EEFD4F69 /* BeatDetector.swift */,
 				078CB839E392E788201DD665 /* BeatGrid.swift */,
 				46242480BEBB0CDD9B45F158 /* NowPlayingController.swift */,
+				4D1395E84111ADD80CC22565 /* OriginalImportService.swift */,
 				D8F8476EAB523378C1F1E046 /* PhotosService.swift */,
 				543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */,
 				94AAA488969D7CF77497859D /* SegmentThumbnailGenerator.swift */,
@@ -301,6 +307,7 @@
 				A88000A1ACD9503F7A9D6143 /* LibraryView.swift in Sources */,
 				1F02ADF6471B01E48A824A49 /* Models.swift in Sources */,
 				3D990657ED52C04DBB04687A /* NowPlayingController.swift in Sources */,
+				D8739042EECB4AE2C7804C41 /* OriginalImportService.swift in Sources */,
 				F7AD3FACE8B875F1C9DFA310 /* PhotosService.swift in Sources */,
 				03C973FD27336E9DD2EDE507 /* PracticeBeatUI.swift in Sources */,
 				2B90619AE0B5262B774DEAC1 /* PracticeControls.swift in Sources */,
@@ -328,6 +335,7 @@
 				5F405BD1B2F2EB7F30970683 /* LibraryFormatterTests.swift in Sources */,
 				BE33E08127A1601493FB7837 /* LoopEvaluatorTests.swift in Sources */,
 				C376AB20647940A9E53A89D0 /* ModelsTests.swift in Sources */,
+				648013A1A4C23692CD6ED03B /* OriginalImportServiceTests.swift in Sources */,
 				CC6F98E7716925F88449689A /* PhotosServiceTests.swift in Sources */,
 				F35848C14CA3DF06A4EBE554 /* SpeedFormatterTests.swift in Sources */,
 				4181110140BD581DBFB0A380 /* StepTimingTests.swift in Sources */,

--- a/StepBack/Models/Models.swift
+++ b/StepBack/Models/Models.swift
@@ -24,6 +24,12 @@ final class DanceClip: Equatable, Hashable {
     /// original from Photos.
     var trimmedFileName: String?
 
+    /// Filename (in `OriginalStorage.directory`) for a sandboxed copy of the
+    /// imported video. Set on import so segments and beat data survive the
+    /// user deleting the original from Photos. Nil for clips imported before
+    /// this field existed; those keep the legacy PHAsset-only behavior.
+    var originalFileName: String?
+
     @Relationship(deleteRule: .cascade, inverse: \ClipSegment.clip)
     var segments: [ClipSegment] = []
 
@@ -82,6 +88,19 @@ final class DanceClip: Equatable, Hashable {
     var trimmedFileURL: URL? {
         guard let trimmedFileName else { return nil }
         return TrimStorage.fileURL(name: trimmedFileName)
+    }
+
+    /// Resolved sandbox URL for the imported original copy, when one exists.
+    var originalFileURL: URL? {
+        guard let originalFileName else { return nil }
+        return OriginalStorage.fileURL(name: originalFileName)
+    }
+
+    /// Best local file to play back: trim if present, otherwise the
+    /// sandboxed original. Falls through to nil for legacy PHAsset-only
+    /// clips, which the caller resolves via `PhotosService`.
+    var preferredLocalFileURL: URL? {
+        trimmedFileURL ?? originalFileURL
     }
 }
 

--- a/StepBack/Services/OriginalImportService.swift
+++ b/StepBack/Services/OriginalImportService.swift
@@ -1,0 +1,65 @@
+import AVFoundation
+import Foundation
+
+enum OriginalImportError: Error, LocalizedError {
+    case copyFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .copyFailed(let detail): "Couldn't copy video into the app: \(detail)"
+        }
+    }
+}
+
+/// Where sandboxed originals live. Same rationale as `TrimStorage`:
+/// `Documents/` (not `tmp` or `caches`) so the OS can't reclaim them
+/// mid-practice, and we own them across PHAsset deletions.
+enum OriginalStorage {
+    static var directory: URL {
+        FileManager.default
+            .urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("Originals", isDirectory: true)
+    }
+
+    static func ensureDirectoryExists() throws {
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+    }
+
+    static func fileURL(name: String) -> URL {
+        directory.appendingPathComponent(name)
+    }
+
+    static func deleteIfExists(name: String) {
+        let url = fileURL(name: name)
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+/// Copies an `AVURLAsset` resolved from the user's Photos library into the
+/// app sandbox so the clip survives the original being deleted from Photos.
+/// Returns the on-disk filename inside `OriginalStorage.directory`.
+struct OriginalImportService {
+
+    func importCopy(of urlAsset: AVURLAsset) async throws -> String {
+        try OriginalStorage.ensureDirectoryExists()
+
+        let sourceExt = urlAsset.url.pathExtension
+        let ext = sourceExt.isEmpty ? "mov" : sourceExt
+        let fileName = "\(UUID().uuidString).\(ext)"
+        let destination = OriginalStorage.fileURL(name: fileName)
+
+        // Stale destination from a prior crashed copy — extremely unlikely
+        // given the UUID, but cheap insurance.
+        try? FileManager.default.removeItem(at: destination)
+
+        do {
+            try FileManager.default.copyItem(at: urlAsset.url, to: destination)
+            return fileName
+        } catch {
+            throw OriginalImportError.copyFailed(error.localizedDescription)
+        }
+    }
+}

--- a/StepBack/Views/LibraryView.swift
+++ b/StepBack/Views/LibraryView.swift
@@ -23,6 +23,7 @@ struct LibraryView: View {
 
     private let columns = [GridItem(.adaptive(minimum: 140), spacing: 12)]
     private let photosService: PhotosServicing = PhotosService()
+    private let originalImporter = OriginalImportService()
 
     var body: some View {
         NavigationStack {
@@ -340,6 +341,11 @@ struct LibraryView: View {
         let title = defaultTitle(for: urlAsset, identifier: identifier)
         let creationDate = creationDate(for: identifier) ?? Date()
 
+        // Own the bytes so segments / beat data survive the user deleting the
+        // original from Photos. `try?` because failure is non-fatal: we still
+        // import with PHAsset-only fallback rather than blocking the user.
+        let originalFileName = try? await originalImporter.importCopy(of: urlAsset)
+
         let clip = DanceClip(
             title: title,
             assetIdentifier: identifier,
@@ -347,6 +353,7 @@ struct LibraryView: View {
             thumbnailData: thumbnail,
             durationSeconds: duration.isFinite ? duration : 0
         )
+        clip.originalFileName = originalFileName
         modelContext.insert(clip)
         try modelContext.save()
     }
@@ -376,15 +383,28 @@ struct LibraryView: View {
     private func commitDelete(_ target: DeleteConfirmation) {
         switch target {
         case .single(let clip):
+            cleanupSandboxFiles(for: clip)
             modelContext.delete(clip)
         case .bulk(let clips):
             for clip in clips {
+                cleanupSandboxFiles(for: clip)
                 modelContext.delete(clip)
             }
             exitSelectionMode()
         }
         try? modelContext.save()
         deleteConfirmation = nil
+    }
+
+    /// Removes the sandboxed original + trim files for a clip. Safe to call
+    /// for legacy clips that have neither — both branches no-op when nil.
+    private func cleanupSandboxFiles(for clip: DanceClip) {
+        if let name = clip.originalFileName {
+            OriginalStorage.deleteIfExists(name: name)
+        }
+        if let name = clip.trimmedFileName {
+            TrimStorage.deleteIfExists(name: name)
+        }
     }
 }
 

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -22,7 +22,7 @@ struct PracticeView: View {
         _vm = StateObject(
             wrappedValue: PracticePlayerViewModel(
                 assetIdentifier: clip.assetIdentifier,
-                localFileURL: clip.trimmedFileURL
+                localFileURL: clip.preferredLocalFileURL
             )
         )
     }
@@ -105,7 +105,9 @@ struct PracticeView: View {
         }
         .fullScreenCover(isPresented: $trimSheetPresented, onDismiss: {
             // After a trim the underlying file has changed; rebind the player.
-            Task { await vm.reloadAsset(localFileURL: clip.trimmedFileURL) }
+            // Fall through to the sandboxed original if the user backed out
+            // of the trim sheet without exporting.
+            Task { await vm.reloadAsset(localFileURL: clip.preferredLocalFileURL) }
         }) {
             TrimView(clip: clip, player: vm.player, initialDuration: vm.duration)
         }
@@ -240,12 +242,6 @@ struct PracticeView: View {
                 Spacer()
             }
             SpeedPills(selected: vm.speed, onSelect: vm.setSpeed(_:))
-            SegmentList(
-                segments: clip.segments.sorted { ($0.orderIndex, $0.startSeconds) < ($1.orderIndex, $1.startSeconds) },
-                activeID: vm.activeSegmentID,
-                onPlay: vm.playSegment,
-                onEdit: { editingSegment = $0 }
-            )
             SegmentList(
                 segments: clip.segments.sorted { ($0.orderIndex, $0.startSeconds) < ($1.orderIndex, $1.startSeconds) },
                 activeID: vm.activeSegmentID,

--- a/StepBackTests/ModelsTests.swift
+++ b/StepBackTests/ModelsTests.swift
@@ -36,6 +36,9 @@ final class ModelsTests: XCTestCase {
         XCTAssertTrue(clip.segments.isEmpty)
         XCTAssertTrue(clip.tags.isEmpty)
         XCTAssertNil(clip.trimmedFileName)
+        XCTAssertNil(clip.originalFileName)
+        XCTAssertNil(clip.originalFileURL)
+        XCTAssertNil(clip.preferredLocalFileURL)
 
         // Beat analysis defaults
         XCTAssertNil(clip.bpm)
@@ -105,6 +108,30 @@ final class ModelsTests: XCTestCase {
     func testClipSegmentDurationNeverNegative() {
         let segment = ClipSegment(title: "Weird", startSeconds: 10, endSeconds: 5)
         XCTAssertEqual(segment.durationSeconds, 0)
+    }
+
+    // MARK: - Local file URL preference
+
+    func testPreferredLocalFileURLPrefersTrimOverOriginal() {
+        let clip = DanceClip(title: "Both", assetIdentifier: "ASSET-PRIO")
+        clip.originalFileName = "orig.mov"
+        clip.trimmedFileName = "trim.mov"
+
+        XCTAssertEqual(clip.preferredLocalFileURL, clip.trimmedFileURL)
+        XCTAssertNotEqual(clip.preferredLocalFileURL, clip.originalFileURL)
+    }
+
+    func testPreferredLocalFileURLFallsThroughToOriginal() {
+        let clip = DanceClip(title: "Original only", assetIdentifier: "ASSET-ORIG")
+        clip.originalFileName = "orig.mov"
+
+        XCTAssertEqual(clip.preferredLocalFileURL, clip.originalFileURL)
+    }
+
+    func testOriginalFileURLNilWhenNoFileName() {
+        let clip = DanceClip(title: "Legacy", assetIdentifier: "ASSET-LEGACY")
+        XCTAssertNil(clip.originalFileURL)
+        XCTAssertNil(clip.preferredLocalFileURL)
     }
 
     // MARK: - Tag

--- a/StepBackTests/OriginalImportServiceTests.swift
+++ b/StepBackTests/OriginalImportServiceTests.swift
@@ -1,0 +1,128 @@
+@testable import StepBack
+import AVFoundation
+import XCTest
+
+final class OriginalImportServiceTests: XCTestCase {
+
+    private var temporarySource: URL!
+    private var copiedFileNames: [String] = []
+
+    override func setUpWithError() throws {
+        // A tiny non-empty file we can copy without bringing in real video assets.
+        let tmpName = "stepback-test-\(UUID().uuidString).mov"
+        temporarySource = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent(tmpName)
+        try Data("not really a video".utf8)
+            .write(to: temporarySource)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: temporarySource)
+        for name in copiedFileNames {
+            OriginalStorage.deleteIfExists(name: name)
+        }
+        copiedFileNames.removeAll()
+    }
+
+    // MARK: - OriginalStorage
+
+    func testOriginalStorageDirectoryIsUnderDocumentsAndIsAlwaysCreatable() throws {
+        let docs = FileManager.default
+            .urls(for: .documentDirectory, in: .userDomainMask)[0]
+        XCTAssertTrue(
+            OriginalStorage.directory.path.hasPrefix(docs.path),
+            "Originals must live under Documents/, not tmp/ or caches/"
+        )
+
+        try OriginalStorage.ensureDirectoryExists()
+        var isDirectory: ObjCBool = false
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: OriginalStorage.directory.path,
+                isDirectory: &isDirectory
+            )
+        )
+        XCTAssertTrue(isDirectory.boolValue)
+    }
+
+    func testOriginalStorageFileURLAppendsName() {
+        let url = OriginalStorage.fileURL(name: "abc.mov")
+        XCTAssertEqual(url.lastPathComponent, "abc.mov")
+        XCTAssertEqual(
+            url.deletingLastPathComponent().path,
+            OriginalStorage.directory.path
+        )
+    }
+
+    func testDeleteIfExistsIsIdempotentOnMissingFile() {
+        // No throw, no crash for a name that was never written.
+        OriginalStorage.deleteIfExists(name: "never-written-\(UUID().uuidString).mov")
+    }
+
+    // MARK: - OriginalImportService
+
+    func testImportCopyWritesFileAndReturnsName() async throws {
+        let asset = AVURLAsset(url: temporarySource)
+        let service = OriginalImportService()
+
+        let fileName = try await service.importCopy(of: asset)
+        copiedFileNames.append(fileName)
+
+        let destination = OriginalStorage.fileURL(name: fileName)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: destination.path))
+        XCTAssertEqual(
+            try Data(contentsOf: destination),
+            try Data(contentsOf: temporarySource),
+            "The sandboxed copy should byte-match the source."
+        )
+    }
+
+    func testImportCopyPreservesExtension() async throws {
+        let asset = AVURLAsset(url: temporarySource)
+        let fileName = try await OriginalImportService().importCopy(of: asset)
+        copiedFileNames.append(fileName)
+
+        XCTAssertEqual(
+            (fileName as NSString).pathExtension.lowercased(),
+            "mov"
+        )
+    }
+
+    func testImportCopyDefaultsToMovWhenSourceHasNoExtension() async throws {
+        // Construct a copy of the source without an extension so the service
+        // has to fall back to its default.
+        let extlessURL = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("stepback-extless-\(UUID().uuidString)")
+        try FileManager.default.copyItem(at: temporarySource, to: extlessURL)
+        defer { try? FileManager.default.removeItem(at: extlessURL) }
+
+        let asset = AVURLAsset(url: extlessURL)
+        let fileName = try await OriginalImportService().importCopy(of: asset)
+        copiedFileNames.append(fileName)
+
+        XCTAssertEqual(
+            (fileName as NSString).pathExtension.lowercased(),
+            "mov"
+        )
+    }
+
+    func testImportCopyFailsWhenSourceMissing() async {
+        let missingURL = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("stepback-missing-\(UUID().uuidString).mov")
+        let asset = AVURLAsset(url: missingURL)
+
+        do {
+            _ = try await OriginalImportService().importCopy(of: asset)
+            XCTFail("Expected copyFailed for a non-existent source.")
+        } catch let error as OriginalImportError {
+            switch error {
+            case .copyFailed: break
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
Closes #61.

## Why

`DanceClip.assetIdentifier` points at a `PHAsset` `localIdentifier`. If the user deletes the source video from Photos (or the asset becomes unresolvable for any other reason — iCloud cycling, corruption, library reset), every annotation we've persisted around it — segments, beat times, downbeat anchor, notes, tags — silently orphans. The metadata is durable in SwiftData; the underlying media is not. That's also a non-starter for the planned CloudKit sync (#55), which needs a stable local source of truth on each device.

## What changed

- **`OriginalImportService` + `OriginalStorage`** — new service mirroring the existing trim machinery. Sandbox path is `Documents/Originals/<uuid>.<ext>`. Same rationale as `TrimStorage`: not `tmp/`, not `caches/`, so the OS can't reclaim mid-practice and the file survives reboot.
- **`DanceClip.originalFileName` + `originalFileURL` + `preferredLocalFileURL`** — optional field so existing clips migrate cleanly. `preferredLocalFileURL` returns `trim ?? original`, used by `PracticeView` and the trim-onDismiss reload path.
- **`LibraryView.importOne`** — copies bytes after `resolveAVAsset`. Wrapped in `try?` so a clip still imports with PHAsset-only fallback if the copy fails (e.g. weird HEIC video resource shapes), instead of blocking the user.
- **`LibraryView.commitDelete`** — cleans up sandboxed originals + trims when a clip is deleted, so we don't leak per-clip bytes into `Documents/`.
- **`PracticeView`** — passes `preferredLocalFileURL` to the player VM. No-op for legacy clips (still resolves via PHAsset), durable for new ones.
- **Bonus**: removed a duplicate `SegmentList` row in `PracticeView` that rendered patterns twice (leftover from an earlier merge).

## Tradeoff

Storage roughly doubles per imported clip (Photos copy + ours). For a personal-use library of dance clips it's fine; if it ever becomes a problem we can add a per-clip "don't own bytes" toggle.

## Out of scope

- Migrating existing PHAsset-only clips. The simplest path forward is just to re-import. A future PR can add a one-shot batch migration.
- CloudKit asset sync — separate work (#55), but this change is a precondition.

## Tests

86/86 pass (was 76). Added:
- 5 `OriginalImportServiceTests` covering storage paths, byte-identical copy, extension preservation, default-extension fallback, missing-source error.
- 3 `ModelsTests` covering `preferredLocalFileURL` priority (trim > original) and nil fallthrough for legacy clips.
