### PR TITLE
Versioned SwiftData schema baseline (#56)

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		72A012D3DCF8FA13D69C1868 /* KeepScreenAwake.swift in Sources */ = {isa = PBXBuildFile; fileRef = E56B6CE778D3BD0C5B1B248B /* KeepScreenAwake.swift */; };
 		76D520F6EC5A0A8E57C8AAA1 /* BeatDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6BC077A9FA8B51D07C178A0 /* BeatDetectorTests.swift */; };
 		7FA3BBA0113FDF3282819E84 /* PracticePlayerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */; };
+		8772C73FA1983B9E8A39FAD8 /* Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5445312DC1A378A65F963DD7 /* Schema.swift */; };
+		9799CACB6C924AC1940D9FE3 /* StepBackMigrationPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808127290713ACE9855DA35E /* StepBackMigrationPlanTests.swift */; };
 		9DCAAD9B2DCFAEE83A9D4879 /* TrimView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF9D9B68E730BA51C86D70A /* TrimView.swift */; };
 		9F90D5641396A9BF3E7A09FE /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E94F050959741028A8574D /* RootView.swift */; };
 		A49A15759EECD46EC5E3A694 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D07843122196F5F0DA539D1 /* Theme.swift */; };
@@ -69,12 +71,14 @@
 		46ED8A21F9D36A90E3306D55 /* StepBackTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = StepBackTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4D1395E84111ADD80CC22565 /* OriginalImportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OriginalImportService.swift; sourceTree = "<group>"; };
 		543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticePlayerViewModel.swift; sourceTree = "<group>"; };
+		5445312DC1A378A65F963DD7 /* Schema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Schema.swift; sourceTree = "<group>"; };
 		56E94F050959741028A8574D /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		57317F752B65258CB2D04530 /* LoopEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopEvaluatorTests.swift; sourceTree = "<group>"; };
 		6745FF48B10D28A5ED4BB568 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
 		6BCED6C8E1CE7A48B341C8B1 /* TrimExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimExportService.swift; sourceTree = "<group>"; };
 		7093A077C0A2C139BD7BDD29 /* BeatGridTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeatGridTests.swift; sourceTree = "<group>"; };
 		71643D36F7F8D028B560F012 /* TrimAnnotationShifter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimAnnotationShifter.swift; sourceTree = "<group>"; };
+		808127290713ACE9855DA35E /* StepBackMigrationPlanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepBackMigrationPlanTests.swift; sourceTree = "<group>"; };
 		848D52E156E709AA0226CEE8 /* ModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsTests.swift; sourceTree = "<group>"; };
 		8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryFormatterTests.swift; sourceTree = "<group>"; };
 		8D25E6771271EDD5B867F61E /* ClipEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipEditView.swift; sourceTree = "<group>"; };
@@ -113,6 +117,7 @@
 			isa = PBXGroup;
 			children = (
 				6745FF48B10D28A5ED4BB568 /* Models.swift */,
+				5445312DC1A378A65F963DD7 /* Schema.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -145,6 +150,7 @@
 				EF4094CC2957462A284F735A /* OriginalImportServiceTests.swift */,
 				B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */,
 				16E676751B59ED083837CE39 /* SpeedFormatterTests.swift */,
+				808127290713ACE9855DA35E /* StepBackMigrationPlanTests.swift */,
 				DB3B8C1BB7ACE2D1C13C7200 /* StepTimingTests.swift */,
 				B7C112AEA59633E85CF8267D /* ThemeTests.swift */,
 				EB991AFC28C64366954E1D19 /* TrimAnnotationShifterTests.swift */,
@@ -314,6 +320,7 @@
 				7FA3BBA0113FDF3282819E84 /* PracticePlayerViewModel.swift in Sources */,
 				527B9B596B00D2C774173ECA /* PracticeView.swift in Sources */,
 				9F90D5641396A9BF3E7A09FE /* RootView.swift in Sources */,
+				8772C73FA1983B9E8A39FAD8 /* Schema.swift in Sources */,
 				AD47C4CE36AF1FD4FF011BCC /* SegmentThumbnailGenerator.swift in Sources */,
 				1EC09265A1CD5B1E67415B39 /* StepBackApp.swift in Sources */,
 				622A6663058E88A57B465B62 /* StepTiming.swift in Sources */,
@@ -338,6 +345,7 @@
 				648013A1A4C23692CD6ED03B /* OriginalImportServiceTests.swift in Sources */,
 				CC6F98E7716925F88449689A /* PhotosServiceTests.swift in Sources */,
 				F35848C14CA3DF06A4EBE554 /* SpeedFormatterTests.swift in Sources */,
+				9799CACB6C924AC1940D9FE3 /* StepBackMigrationPlanTests.swift in Sources */,
 				4181110140BD581DBFB0A380 /* StepTimingTests.swift in Sources */,
 				C97E59DA25A51E16ECA03607 /* ThemeTests.swift in Sources */,
 				AB9467B4E5F44BFF1AA916B1 /* TrimAnnotationShifterTests.swift in Sources */,

--- a/StepBack/Models/Schema.swift
+++ b/StepBack/Models/Schema.swift
@@ -1,0 +1,41 @@
+import Foundation
+import SwiftData
+
+/// Versioned schema baseline for StepBack's SwiftData store.
+///
+/// V1 is the *current* on-disk shape. There is intentionally no V0 covering
+/// the pre-`LoopMarker`-removal era: that change shipped as an accepted
+/// solo-tester data loss (see commit `8a11bdb`), so a backwards-looking
+/// migration would only recover data nobody has. The value of declaring V1
+/// now is forward-looking — when the next schema change lands (CloudKit
+/// sync, on-disk thumbnails, new `ClipSegment` fields, etc.), it ships as a
+/// V2 with an explicit `MigrationStage` between V1 and V2.
+///
+/// To add V2: copy this enum to `SchemaV2`, declare V2's `models`, then
+/// append a stage in `StepBackMigrationPlan.stages` describing the V1→V2
+/// transition (lightweight if additive-only, custom for renames or data
+/// transformations).
+enum SchemaV1: VersionedSchema {
+    static let versionIdentifier: Schema.Version = .init(1, 0, 0)
+
+    static var models: [any PersistentModel.Type] {
+        [DanceClip.self, Tag.self, ClipSegment.self]
+    }
+}
+
+/// SwiftData migration plan for StepBack.
+///
+/// Today this carries a single baseline (V1) with no stages — meaning any
+/// existing on-device store is treated as already-V1 and opened with
+/// SwiftData's lightweight migration. The plan is wired through
+/// `ModelContainer` regardless so future versions slot in without having
+/// to rewrite the container construction at the call site.
+enum StepBackMigrationPlan: SchemaMigrationPlan {
+    static var schemas: [any VersionedSchema.Type] {
+        [SchemaV1.self]
+    }
+
+    static var stages: [MigrationStage] {
+        []
+    }
+}

--- a/StepBack/StepBackApp.swift
+++ b/StepBack/StepBackApp.swift
@@ -4,6 +4,9 @@ import SwiftUI
 
 @main
 struct StepBackApp: App {
+
+    private let container: ModelContainer
+
     init() {
         // Route playback through .playback so video audio ignores the silent
         // switch — otherwise the phone's ringer toggle mutes practice clips.
@@ -13,12 +16,26 @@ struct StepBackApp: App {
             try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .moviePlayback)
             try? AVAudioSession.sharedInstance().setActive(true)
         }
+
+        do {
+            let schema = Schema(versionedSchema: SchemaV1.self)
+            container = try ModelContainer(
+                for: schema,
+                migrationPlan: StepBackMigrationPlan.self,
+                configurations: ModelConfiguration(schema: schema)
+            )
+        } catch {
+            // For a personal-use app, surfacing this as a hard crash beats
+            // silently corrupting the store. If the migration plan ever
+            // fails on a real device, recovery is "delete app, reinstall."
+            fatalError("Failed to create StepBack ModelContainer: \(error)")
+        }
     }
 
     var body: some Scene {
         WindowGroup {
             RootView()
         }
-        .modelContainer(for: [DanceClip.self, Tag.self, ClipSegment.self])
+        .modelContainer(container)
     }
 }

--- a/StepBackTests/StepBackMigrationPlanTests.swift
+++ b/StepBackTests/StepBackMigrationPlanTests.swift
@@ -1,0 +1,61 @@
+@testable import StepBack
+import SwiftData
+import XCTest
+
+@MainActor
+final class StepBackMigrationPlanTests: XCTestCase {
+
+    // MARK: - SchemaV1
+
+    func testSchemaV1IsVersionOneZeroZero() {
+        XCTAssertEqual(SchemaV1.versionIdentifier, Schema.Version(1, 0, 0))
+    }
+
+    func testSchemaV1ContainsExactlyTheCurrentLiveModels() {
+        // The point of this test is to fail loudly when someone adds a new
+        // @Model type without versioning it. New models should land as part
+        // of a SchemaV2 + migration stage, not by quietly extending V1.
+        let names = Set(SchemaV1.models.map { String(describing: $0) })
+        XCTAssertEqual(names, ["DanceClip", "Tag", "ClipSegment"])
+    }
+
+    // MARK: - Migration plan
+
+    func testMigrationPlanRegistersOnlySchemaV1() {
+        let names = StepBackMigrationPlan.schemas.map { String(describing: $0) }
+        XCTAssertEqual(names, ["SchemaV1"])
+    }
+
+    func testMigrationPlanHasNoStagesForBaseline() {
+        // V1 is the baseline; the first real stage lands with V2.
+        XCTAssertTrue(StepBackMigrationPlan.stages.isEmpty)
+    }
+
+    // MARK: - End-to-end container construction
+
+    func testContainerOpensWithMigrationPlan() throws {
+        // Smoke test: a fresh in-memory container should construct cleanly
+        // when we route through SchemaV1 + StepBackMigrationPlan, and should
+        // accept inserts of every live model type.
+        let schema = Schema(versionedSchema: SchemaV1.self)
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: schema,
+            migrationPlan: StepBackMigrationPlan.self,
+            configurations: config
+        )
+
+        let context = ModelContext(container)
+        let clip = DanceClip(title: "Test", assetIdentifier: "ASSET-MIG")
+        let tag = Tag(name: "tag", colorHex: "#FFFFFF")
+        let segment = ClipSegment(title: "Seg", startSeconds: 0, endSeconds: 1, clip: clip)
+        context.insert(clip)
+        context.insert(tag)
+        context.insert(segment)
+        try context.save()
+
+        XCTAssertEqual(try context.fetchCount(FetchDescriptor<DanceClip>()), 1)
+        XCTAssertEqual(try context.fetchCount(FetchDescriptor<Tag>()), 1)
+        XCTAssertEqual(try context.fetchCount(FetchDescriptor<ClipSegment>()), 1)
+    }
+}


### PR DESCRIPTION
Closes #56.

## Why

The LoopMarker removal in `8a11bdb` shipped as accepted solo-tester data loss — fine then, but it left the schema unversioned. Any future change (the just-merged `originalFileName`, the planned CloudKit sync #55, on-disk thumbnails #54, new `ClipSegment` fields) carries the same "silently drops rows on store-mismatch" risk. The fix isn't to retroactively migrate LoopMarker data nobody has — it's to declare a versioned baseline now so the *next* change has a real migration path.

## What changed

- **`StepBack/Models/Schema.swift`** — `SchemaV1` (`VersionedSchema`) listing the live model types, plus `StepBackMigrationPlan` (`SchemaMigrationPlan`) registering V1.
- **`StepBack/StepBackApp.swift`** — manually constructs the `ModelContainer` with `migrationPlan: StepBackMigrationPlan.self`. Hard-fails on construction error: for a personal-use app, "delete app, reinstall" beats silently corrupting the store.
- **`StepBackTests/StepBackMigrationPlanTests.swift`** — 5 new tests:
  - `SchemaV1` version is `(1, 0, 0)`
  - `SchemaV1.models` contains exactly `{DanceClip, Tag, ClipSegment}` (fails loud if a new `@Model` is added without versioning it)
  - Plan registers only `SchemaV1`
  - Plan has no stages yet (V2 will add the first one)
  - Smoke test: in-memory container builds via the plan and accepts inserts of every live type

## How V2 lands later

Add a `SchemaV2` enum mirroring V1 with the new shape, append it to `StepBackMigrationPlan.schemas`, and register a `MigrationStage` (lightweight if additive-only, custom for renames or data transforms) in `stages`. No changes needed at the container call site.

## Tests

91/91 pass (was 86).

## Out of scope

- Backwards migration of pre-V1 (pre-LoopMarker-removal) stores — see commit `8a11bdb`.
