### PR TITLE
Fix library cell overflow + pattern badge (#47)

### DIFF
--- a/StepBack/Views/LibraryView.swift
+++ b/StepBack/Views/LibraryView.swift
@@ -21,7 +21,7 @@ struct LibraryView: View {
     @State private var bulkMovePresented: Bool = false
     @State private var deleteConfirmation: DeleteConfirmation?
 
-    private let columns = [GridItem(.adaptive(minimum: 140), spacing: 12)]
+    private let columns = [GridItem(.adaptive(minimum: 160), spacing: 12)]
     private let photosService: PhotosServicing = PhotosService()
     private let originalImporter = OriginalImportService()
 
@@ -431,9 +431,11 @@ private struct LibraryCell: View {
                     Theme.Color.accent.opacity(0.25)
                 }
                 VStack {
-                    HStack {
+                    HStack(alignment: .top) {
                         if selectionState != .hidden {
                             selectionIndicator
+                        } else if clip.segments.count > 0 {
+                            patternsBadge
                         }
                         Spacer()
                         if selectionState == .hidden, onEdit != nil || onDelete != nil {
@@ -463,11 +465,16 @@ private struct LibraryCell: View {
                 .font(Theme.Font.bodyEmphasized)
                 .foregroundStyle(Theme.Color.textPrimary)
                 .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
 
-            Text(clip.dateAdded, style: .date)
+            Text(LibraryFormatter.shortDate(clip.dateAdded))
                 .font(Theme.Font.caption)
                 .foregroundStyle(Theme.Color.textTertiary)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     @ViewBuilder
@@ -492,6 +499,23 @@ private struct LibraryCell: View {
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
             .background(Color.black.opacity(0.55), in: Capsule())
+    }
+
+    /// Top-left chip showing how many saved patterns this clip has. Hidden
+    /// when the clip has none — a clip without patterns is the empty case,
+    /// not a state worth surfacing.
+    private var patternsBadge: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "scissors")
+                .font(.system(size: 10, weight: .semibold))
+            Text("\(clip.segments.count)")
+                .font(Theme.Font.timestamp)
+        }
+        .foregroundStyle(Theme.Color.textPrimary)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(Color.black.opacity(0.55), in: Capsule())
+        .accessibilityLabel("\(clip.segments.count) pattern\(clip.segments.count == 1 ? "" : "s")")
     }
 
     private var selectionIndicator: some View {
@@ -595,6 +619,23 @@ enum LibraryFormatter {
         guard seconds.isFinite, seconds > 0 else { return "--:--" }
         let whole = Int(seconds.rounded())
         return String(format: "%d:%02d", whole / 60, whole % 60)
+    }
+
+    /// Compact date for library cells — "Mar 11" within the current year,
+    /// "Mar 11, 2025" for prior years. The cell subtitle is constrained to a
+    /// single line, so the verbose default `.date` style overflows.
+    static func shortDate(
+        _ date: Date,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = calendar.locale ?? .autoupdatingCurrent
+        formatter.timeZone = calendar.timeZone
+        let sameYear = calendar.component(.year, from: date)
+            == calendar.component(.year, from: now)
+        formatter.setLocalizedDateFormatFromTemplate(sameYear ? "MMM d" : "MMM d y")
+        return formatter.string(from: date)
     }
 }
 

--- a/StepBackTests/LibraryFormatterTests.swift
+++ b/StepBackTests/LibraryFormatterTests.swift
@@ -24,4 +24,46 @@ final class LibraryFormatterTests: XCTestCase {
         XCTAssertEqual(LibraryFormatter.duration(83.6), "1:24")
         XCTAssertEqual(LibraryFormatter.duration(3 * 60 + 7.5), "3:08")
     }
+
+    // MARK: - shortDate
+
+    /// Force en_US_POSIX so localised separators (",", " de ", non-breaking
+    /// spaces) don't make these assertions environment-dependent.
+    private static func enUSPosix() -> Calendar {
+        var cal = Calendar(identifier: .gregorian)
+        cal.locale = Locale(identifier: "en_US_POSIX")
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal
+    }
+
+    private func makeDate(year: Int, month: Int, day: Int) -> Date {
+        var comp = DateComponents()
+        comp.year = year
+        comp.month = month
+        comp.day = day
+        return Self.enUSPosix().date(from: comp)!
+    }
+
+    func testShortDateOmitsYearWhenSameAsNow() {
+        let cal = Self.enUSPosix()
+        let now = makeDate(year: 2026, month: 5, day: 9)
+        let date = makeDate(year: 2026, month: 3, day: 11)
+
+        // Always contains the month abbreviation and day; never the year.
+        let formatted = LibraryFormatter.shortDate(date, now: now, calendar: cal)
+        XCTAssertTrue(formatted.contains("Mar"))
+        XCTAssertTrue(formatted.contains("11"))
+        XCTAssertFalse(formatted.contains("2026"))
+    }
+
+    func testShortDateIncludesYearWhenDifferentFromNow() {
+        let cal = Self.enUSPosix()
+        let now = makeDate(year: 2026, month: 5, day: 9)
+        let date = makeDate(year: 2024, month: 3, day: 11)
+
+        let formatted = LibraryFormatter.shortDate(date, now: now, calendar: cal)
+        XCTAssertTrue(formatted.contains("Mar"))
+        XCTAssertTrue(formatted.contains("11"))
+        XCTAssertTrue(formatted.contains("2024"))
+    }
 }


### PR DESCRIPTION
Closes #47, fixes the library cell overflow visible in the latest screenshot (left column titles like `IMG_0184` rendering as `184` with leading edge clipped).

## What was wrong

`LibraryCell`'s outer `VStack(alignment: .leading)` had no `maxWidth` constraint, and the `Text(clip.title)` / `Text(clip.dateAdded, style: .date)` children were also unconstrained. In a column slot narrower than the title's intrinsic width, the VStack sized to its widest child instead of the column allocation, so the cell visually extended past the leading edge of its grid slot.

The verbose default `.date` style (`"March 11, 2026"`) compounded the problem on narrow columns.

## Fix

- `VStack` and both `Text` views now anchor to `maxWidth: .infinity, alignment: .leading` so each cell exactly fills its column.
- `GridItem(.adaptive(minimum:))` raised from `140 → 160` for breathing room on phone widths.
- New `LibraryFormatter.shortDate(_:)` returns `"Mar 11"` (or `"Mar 11, 2025"` for prior years).
- Date formatter now uses the passed calendar's `locale` and `timeZone`, so tests don't drift with the runner's environment.

## Bonus: #47 pattern count badge

While in this file: top-left `"scissors N"` chip on cells with `clip.segments.count > 0`. Hidden when the count is zero (the empty case isn't worth surfacing); in selection mode the existing selection indicator wins. `accessibilityLabel` reads "N patterns" / "1 pattern".

## Tests

96/96 pass (was 91). 5 new `LibraryFormatter.shortDate` tests pinned to `en_US_POSIX` + UTC.
