### PR TITLE
Visual beat pulse on BPM badge (#65)

### DIFF
--- a/StepBack/Services/PracticePlayerViewModel.swift
+++ b/StepBack/Services/PracticePlayerViewModel.swift
@@ -29,7 +29,18 @@ final class PracticePlayerViewModel: ObservableObject {
     // outside the normal actor-isolated execution path — so it is marked
     // nonisolated(unsafe) rather than dragged through MainActor.
     private nonisolated(unsafe) var timeObserver: Any?
+    private nonisolated(unsafe) var beatBoundaryObserver: Any?
+    private var configuredBeatTimes: [Double] = []
+    private var configuredDownbeatIndices: Set<Int> = []
     private var playerItem: AVPlayerItem?
+
+    /// Increments every time the player crosses a beat boundary. UI binds to
+    /// this rather than `currentTime` so the pulse animation only re-renders
+    /// on beat transitions, not on every periodic time observer tick.
+    @Published private(set) var beatPulseID: Int = 0
+    /// Whether the most recent beat boundary was a downbeat (count 1). UI
+    /// uses this to scale the pulse bigger on the first beat of a measure.
+    @Published private(set) var lastBeatWasDownbeat: Bool = false
 
     private let assetIdentifier: String
     private var localFileURL: URL?
@@ -52,6 +63,47 @@ final class PracticePlayerViewModel: ObservableObject {
     deinit {
         if let timeObserver {
             player.removeTimeObserver(timeObserver)
+        }
+        if let beatBoundaryObserver {
+            player.removeTimeObserver(beatBoundaryObserver)
+        }
+    }
+
+    // MARK: - Beat pulse
+
+    /// Registers boundary-time observers at every entry in `beatTimes`.
+    /// AVPlayer fires the callback when playback crosses each timestamp,
+    /// which is more accurate (and cheaper) than checking against
+    /// `currentTime` from the periodic observer. Idempotent — calling again
+    /// tears down the previous observer first, so it's safe to invoke when
+    /// beats are re-detected.
+    func configureBeatPulse(beatTimes: [Double], downbeatIndices: Set<Int>) {
+        if let beatBoundaryObserver {
+            player.removeTimeObserver(beatBoundaryObserver)
+            self.beatBoundaryObserver = nil
+        }
+        configuredBeatTimes = beatTimes
+        configuredDownbeatIndices = downbeatIndices
+        guard !beatTimes.isEmpty else { return }
+
+        let nsValues = beatTimes.map {
+            NSValue(time: CMTime(seconds: $0, preferredTimescale: 600))
+        }
+        beatBoundaryObserver = player.addBoundaryTimeObserver(
+            forTimes: nsValues,
+            queue: .main
+        ) { [weak self] in
+            // queue: .main → safe to assume MainActor.
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                let now = self.player.currentTime().seconds
+                // The boundary that fired is the latest beat time at or
+                // before `now` (with a small slack for timer jitter).
+                let index = self.configuredBeatTimes.lastIndex { $0 <= now + 0.05 }
+                    ?? 0
+                self.lastBeatWasDownbeat = self.configuredDownbeatIndices.contains(index)
+                self.beatPulseID &+= 1
+            }
         }
     }
 

--- a/StepBack/Views/PracticeBeatUI.swift
+++ b/StepBack/Views/PracticeBeatUI.swift
@@ -10,6 +10,14 @@ struct BPMBadge: View {
     let onDetect: () -> Void
     var onRescale: ((Double) -> Void)?
 
+    /// Increments on every beat boundary. The badge ignores the actual
+    /// value and just keys an animation off changes, so wraparound is safe.
+    var beatPulseID: Int = 0
+    /// Bigger pulse on count 1.
+    var lastBeatWasDownbeat: Bool = false
+
+    @State private var pulseScale: CGFloat = 1.0
+
     var body: some View {
         HStack(spacing: 8) {
             if let bpm {
@@ -41,6 +49,23 @@ struct BPMBadge: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
         .background(Theme.Color.accentSoft, in: Capsule())
+        .scaleEffect(pulseScale)
+        .onChange(of: beatPulseID) { _, _ in
+            triggerPulse(big: lastBeatWasDownbeat)
+        }
+    }
+
+    /// Two-stage scale: snap up fast, ease back. A single `withAnimation`
+    /// would spend half the cycle scaling up, which feels mushy at higher
+    /// BPMs. `delay` chains the return so the snap reads as a *tick*.
+    private func triggerPulse(big: Bool) {
+        let target: CGFloat = big ? 1.18 : 1.08
+        withAnimation(.easeOut(duration: 0.05)) {
+            pulseScale = target
+        }
+        withAnimation(.easeIn(duration: 0.18).delay(0.05)) {
+            pulseScale = 1.0
+        }
     }
 }
 

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -78,7 +78,21 @@ struct PracticeView: View {
                 }
             }
         }
-        .task { await vm.load() }
+        .task {
+            await vm.load()
+            configureBeatPulse()
+        }
+        .onChange(of: clip.beatTimesData) { _, _ in
+            // Re-arm the boundary observer when beats are (re-)detected so
+            // the pulse comes online without requiring a view re-entry.
+            configureBeatPulse()
+        }
+        .onChange(of: clip.firstDownbeatSeconds) { _, _ in
+            // Anchor changes don't change *which* times pulse, but they do
+            // change which are downbeats — re-arm so the bigger-on-1 logic
+            // tracks the new measure boundaries.
+            configureBeatPulse()
+        }
         .onAppear { vm.enableNowPlaying(for: clip) }
         .onDisappear { vm.disableNowPlaying() }
         .keepScreenAwake()
@@ -184,7 +198,9 @@ struct PracticeView: View {
                     measurePosition: measurePosition,
                     beatsPerMeasure: clip.beatsPerMeasure,
                     onDetect: { Task { await detectBeats() } },
-                    onRescale: clip.hasBeatAnalysis ? rescaleBeats : nil
+                    onRescale: clip.hasBeatAnalysis ? rescaleBeats : nil,
+                    beatPulseID: vm.beatPulseID,
+                    lastBeatWasDownbeat: vm.lastBeatWasDownbeat
                 )
                 Spacer()
             }
@@ -343,6 +359,19 @@ extension PracticeView {
         await vm.detectBeats(for: clip) {
             try? modelContext.save()
         }
+        configureBeatPulse()
+    }
+
+    fileprivate func configureBeatPulse() {
+        let downbeats = BeatGrid.downbeatIndices(
+            beatTimes: clip.beatTimes,
+            anchor: clip.firstDownbeatSeconds,
+            beatsPerMeasure: clip.beatsPerMeasure
+        )
+        vm.configureBeatPulse(
+            beatTimes: clip.beatTimes,
+            downbeatIndices: downbeats
+        )
     }
 
     fileprivate func tapOnBeatOne() {


### PR DESCRIPTION
Closes #65.

## Why

The clip's beat grid is currently static — a row of ticks on the scrubber. During practice you don't *feel* the music in the UI, just the timeline. Pulsing the BPM badge in time with the beat (bigger on count 1) makes the practice surface feel like a tool you dance to.

## Mechanism

- `PracticePlayerViewModel.configureBeatPulse(beatTimes:downbeatIndices:)` registers an `AVPlayer.addBoundaryTimeObserver` at every entry in `clip.beatTimes`. Each fire increments `beatPulseID` (with `&+=` for safe wraparound) and flags whether the boundary was a downbeat. Idempotent — calling again tears down the previous observer.
- `BPMBadge` reads `beatPulseID` and `lastBeatWasDownbeat` and animates a two-stage `scaleEffect`: snap up fast on `.easeOut(0.05)`, ease back over 0.18s with a 0.05s delay so the snap reads as a *tick* rather than a wobble at faster BPMs. Bigger amplitude on downbeats (`1.18` vs `1.08`).
- Re-armed on `task` (initial load), `onChange(of: clip.beatTimesData)` (re-detection), `onChange(of: clip.firstDownbeatSeconds)` (anchor move), and after `detectBeats()` completes.

## Why boundary observers vs the existing periodic observer

The periodic time observer ticks every 100ms and would be the obvious place to detect "did we cross a beat." But:
- 100ms is too coarse: at 120 BPM (beat every 500ms), 1/5 of the period is jitter. The pulse would feel offbeat.
- Boundary observers fire *at* the registered time. AVPlayer also collapses missed boundaries during seeks, so scrubbing forward 30 beats fires once, not 30 times — which is what we want.

## Out of scope

- **Haptic feedback** on downbeats — needs an opt-in setting (some users won't want phantom buzzes), tracked separately.
- **Other rhythmic surfaces** (scrubber playhead pulse, video tint flash, dimming the chrome on count 1) — fold in later if v1 lands well.

## Tests

93/93 pass. No new tests: pure beat-grid logic is already covered, and `addBoundaryTimeObserver` doesn't fire without playback (integration-test territory).
