### PR TITLE
Give the video the screen, stop double-letterboxing

### DIFF
--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -149,12 +149,20 @@ struct PracticeView: View {
                 .tint(Theme.Color.accent)
         } else {
             VStack(spacing: 0) {
+                // Don't constrain to 16:9 here — AVPlayerLayer's .resizeAspect
+                // already letterboxes the actual video. A rigid ratio on this
+                // container double-letterboxes (big black bands top/bottom on
+                // tall phone screens for any non-16:9 source). Let the video
+                // claim leftover vertical space; controls keep their intrinsic
+                // height and float beneath.
                 ZoomablePlayerContainer {
                     PlayerSurface(player: vm.player)
                         .scaleEffect(x: vm.mirrored ? -1 : 1, y: 1)
                 }
-                .aspectRatio(16.0 / 9.0, contentMode: .fit)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(Color.black)
+                .layoutPriority(1)
+
                 controls
             }
         }
@@ -190,7 +198,7 @@ struct PracticeView: View {
             anchor: clip.firstDownbeatSeconds,
             beatsPerMeasure: clip.beatsPerMeasure
         )
-        return VStack(spacing: 14) {
+        return VStack(spacing: 10) {
             HStack {
                 BPMBadge(
                     bpm: clip.bpm,
@@ -265,7 +273,8 @@ struct PracticeView: View {
                 onEdit: { editingSegment = $0 }
             )
         }
-        .padding(16)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
     }
 
     private var loopControls: some View {


### PR DESCRIPTION
Addresses the screenshot you shared — wasted space top/bottom around the video on the Practice surface.

## Root cause

The video container was double-letterboxing:

1. SwiftUI forced the container to `.aspectRatio(16/9, contentMode: .fit)`, fitting that 16:9 box into the available vertical space — which produced big black bands top/bottom on tall phone screens for any source whose native aspect didn't match exactly.
2. *Inside* that already-fitted 16:9 box, `AVPlayerLayer.videoGravity = .resizeAspect` letterboxed the actual video again.

So a landscape phone clip got both: SwiftUI shrinking the container vertically, then AVPlayerLayer placing the video inside a smaller-than-needed frame.

## Fix

- Drop the rigid `.aspectRatio(16/9)` on the player container.
- `.frame(maxWidth: .infinity, maxHeight: .infinity)` + `.layoutPriority(1)` so the player claims all the space the controls don't take.
- AVPlayerLayer continues to letterbox aspect-correctly within that flexible frame — but **only once**.
- Tightened the controls VStack (`spacing: 14 → 10`) and switched padding to `.horizontal 14 / .vertical 10` so the chrome takes proportionally less vertical real estate without losing any controls.

## Result

Video roughly doubles in size on a typical iPhone for landscape-source clips. Portrait clips get even more dramatic improvement (whole vertical area instead of a 16:9 strip in the middle).
