### PR TITLE
Compact transport row: A/B + play + speed on one line

### DIFF
--- a/StepBack/Views/PracticeControls.swift
+++ b/StepBack/Views/PracticeControls.swift
@@ -31,6 +31,50 @@ struct SpeedPills: View {
     }
 }
 
+// MARK: - Speed menu (compact form for the practice transport row)
+
+/// Compact speed control for places where a full pill row is too wide.
+/// Shows the current speed as a tinted capsule with a chevron; tapping
+/// opens a Menu with the same set of speeds as `SpeedPills`. Used in the
+/// merged transport row on PracticeView so play / A-B / speed all live on
+/// one line. Keeps `SpeedPills` for the segment sheets, where vertical
+/// space isn't tight and the always-visible options are easier to scan.
+struct SpeedMenuButton: View {
+    let selected: Double
+    let onSelect: (Double) -> Void
+
+    var body: some View {
+        let tint = Theme.Color.speedPillColor(for: selected)
+        Menu {
+            Picker("Practice speed", selection: bindingSpeed) {
+                ForEach(SpeedPills.speeds, id: \.self) { speed in
+                    Text(SpeedFormatter.pill(speed)).tag(speed)
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Text(SpeedFormatter.pill(selected))
+                    .font(.system(.footnote, design: .rounded, weight: .bold))
+                    .foregroundStyle(.black)
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(.black.opacity(0.7))
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(Capsule().fill(tint))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Practice speed: \(SpeedFormatter.pill(selected))")
+    }
+
+    /// Bridges the let-based API (selected + onSelect) into the Binding the
+    /// Picker needs without forcing the parent to hand us one.
+    private var bindingSpeed: Binding<Double> {
+        Binding(get: { selected }, set: onSelect)
+    }
+}
+
 // MARK: - Formatting
 
 enum SpeedFormatter {

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -247,27 +247,7 @@ struct PracticeView: View {
                     .foregroundStyle(Theme.Color.textSecondary)
             }
             actionRow
-            loopControls
-            HStack(spacing: 24) {
-                FrameStepButton(systemName: "backward.frame.fill") {
-                    vm.stepBackward()
-                }
-                Button {
-                    vm.togglePlayPause()
-                } label: {
-                    Image(systemName: vm.isPlaying ? "pause.fill" : "play.fill")
-                        .font(.system(size: 26, weight: .semibold))
-                        .foregroundStyle(.black)
-                        .frame(width: 64, height: 64)
-                        .background(Theme.Color.accent, in: Circle())
-                }
-                .buttonStyle(.plain)
-                FrameStepButton(systemName: "forward.frame.fill") {
-                    vm.stepForward()
-                }
-            }
-            .frame(maxWidth: .infinity)
-            SpeedPills(selected: vm.speed, onSelect: vm.setSpeed(_:))
+            transportRow
             SegmentList(
                 segments: clip.segments.sorted { ($0.orderIndex, $0.startSeconds) < ($1.orderIndex, $1.startSeconds) },
                 activeID: vm.activeSegmentID,
@@ -279,34 +259,63 @@ struct PracticeView: View {
         .padding(.vertical, 10)
     }
 
-    private var loopControls: some View {
-        HStack(spacing: 10) {
-            LoopButton(
-                label: "A",
-                filled: vm.loopStart != nil,
-                caption: vm.loopStart.map(SpeedFormatter.timestamp)
-            ) {
-                vm.markLoopStart()
+    /// Single-row transport: A/B markers on the left, frame-step + play in
+    /// the middle, speed selector on the right. Replaces the previous
+    /// three rows (loop controls / play / speed pills) — which together
+    /// cost ~150pt of vertical chrome on every clip. The compact A/B
+    /// timestamps drop from the buttons here; the loop region is already
+    /// rendered on the scrubber, and the Trim/Save Pattern action row above
+    /// confirms the action visually when the user does something with A/B.
+    private var transportRow: some View {
+        HStack(spacing: 14) {
+            HStack(spacing: 6) {
+                LoopButton(
+                    label: "A",
+                    filled: vm.loopStart != nil,
+                    caption: nil
+                ) {
+                    vm.markLoopStart()
+                }
+                LoopButton(
+                    label: "B",
+                    filled: vm.loopEnd != nil,
+                    caption: nil
+                ) {
+                    vm.markLoopEnd()
+                }
+                if vm.loopStart != nil || vm.loopEnd != nil {
+                    Button {
+                        vm.clearLoop()
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 18))
+                            .foregroundStyle(Theme.Color.textTertiary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Clear loop")
+                }
             }
-            LoopButton(
-                label: "B",
-                filled: vm.loopEnd != nil,
-                caption: vm.loopEnd.map(SpeedFormatter.timestamp)
-            ) {
-                vm.markLoopEnd()
-            }
-            Spacer()
-            if vm.loopStart != nil || vm.loopEnd != nil {
+            Spacer(minLength: 8)
+            HStack(spacing: 18) {
+                FrameStepButton(systemName: "backward.frame.fill") {
+                    vm.stepBackward()
+                }
                 Button {
-                    vm.clearLoop()
+                    vm.togglePlayPause()
                 } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: 22))
-                        .foregroundStyle(Theme.Color.textTertiary)
+                    Image(systemName: vm.isPlaying ? "pause.fill" : "play.fill")
+                        .font(.system(size: 24, weight: .semibold))
+                        .foregroundStyle(.black)
+                        .frame(width: 56, height: 56)
+                        .background(Theme.Color.accent, in: Circle())
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("Clear loop")
+                FrameStepButton(systemName: "forward.frame.fill") {
+                    vm.stepForward()
+                }
             }
+            Spacer(minLength: 8)
+            SpeedMenuButton(selected: vm.speed, onSelect: vm.setSpeed(_:))
         }
     }
 


### PR DESCRIPTION
Resolves "How can we make this UI more compact?" — A/B + play + speed merged into one row, in roughly the layout you described.

## What changed

Three separate rows below the scrubber became one `transportRow`:

```
[A] [B] (X)        [⏮]   [▶]   [⏭]        [1×▾]
```

- **Left** — A/B markers. Clear (X) appears only when one is set. Dropped the timestamp captions next to A and B — the loop region is already rendered on the scrubber, and the new "Save Pattern" pill above confirms the action visually when both are set.
- **Center** — frame-step + play. Big play circle is slightly smaller (64 → 56) to fit the row alongside A/B and speed.
- **Right** — new `SpeedMenuButton`: tinted capsule showing the current speed with a chevron, tapping opens a `Menu` with all six speeds. Same set as `SpeedPills`.

`SpeedPills` is preserved for the segment save/edit sheets, where vertical space isn't tight and all-visible options are easier to scan.

## Net effect

~150pt of vertical chrome reclaimed below the scrubber, no controls removed. The video gets even more of the screen.

## Tests

93/93. No new tests — pure layout consolidation.
