### PR TITLE
Focus mode: slide-down controls toggle

### DIFF
--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -16,6 +16,10 @@ struct PracticeView: View {
     @State private var comparePickerPresented = false
     @State private var compareSecondary: DanceClip?
     @State private var editSheetPresented = false
+    /// Hides the entire control stack so the video can claim the screen.
+    /// Single-tap on the video remains wired to play/pause so pausing
+    /// doesn't require bringing controls back first.
+    @State private var controlsHidden: Bool = false
 
     init(clip: DanceClip) {
         self.clip = clip
@@ -43,6 +47,16 @@ struct PracticeView: View {
             // they're rarer and ergonomic next to the title.
             ToolbarItem(placement: .topBarTrailing) {
                 HStack(spacing: 12) {
+                    Button {
+                        withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                            controlsHidden.toggle()
+                        }
+                    } label: {
+                        Image(systemName: controlsHidden ? "chevron.up" : "chevron.down")
+                            .font(.system(size: 15, weight: .bold))
+                            .foregroundStyle(controlsHidden ? Theme.Color.accent : Theme.Color.textPrimary)
+                    }
+                    .accessibilityLabel(controlsHidden ? "Show controls" : "Hide controls")
                     Button {
                         editSheetPresented = true
                     } label: {
@@ -151,7 +165,7 @@ struct PracticeView: View {
                 // tall phone screens for any non-16:9 source). Let the video
                 // claim leftover vertical space; controls keep their intrinsic
                 // height and float beneath.
-                ZoomablePlayerContainer {
+                ZoomablePlayerContainer(onSingleTap: { vm.togglePlayPause() }) {
                     PlayerSurface(player: vm.player)
                         .scaleEffect(x: vm.mirrored ? -1 : 1, y: 1)
                 }
@@ -159,7 +173,17 @@ struct PracticeView: View {
                 .background(Color.black)
                 .layoutPriority(1)
 
-                controls
+                if !controlsHidden {
+                    controls
+                        // Slide down + fade so the controls feel anchored to
+                        // the bottom edge; an opacity-only swap pops, and a
+                        // height collapse without a translation reads as a
+                        // glitch.
+                        .transition(
+                            .move(edge: .bottom)
+                            .combined(with: .opacity)
+                        )
+                }
             }
             // Without an explicit fill, the parent ZStack's default centering
             // can leave dead space at the bottom even when children are

--- a/StepBack/Views/ZoomablePlayerContainer.swift
+++ b/StepBack/Views/ZoomablePlayerContainer.swift
@@ -10,8 +10,13 @@ import SwiftUI
 struct ZoomablePlayerContainer<Content: View>: View {
 
     private let content: Content
+    private let onSingleTap: (() -> Void)?
 
-    init(@ViewBuilder content: () -> Content) {
+    init(
+        onSingleTap: (() -> Void)? = nil,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.onSingleTap = onSingleTap
         self.content = content()
     }
 
@@ -57,6 +62,12 @@ struct ZoomablePlayerContainer<Content: View>: View {
                             baseScale = scale
                             baseOffset = offset
                         }
+                    }
+                    // Order matters: registering the count: 1 gesture after
+                    // count: 2 lets SwiftUI disambiguate — a quick second tap
+                    // still triggers zoom, not two single-tap pauses.
+                    .onTapGesture(count: 1) {
+                        onSingleTap?()
                     }
             }
             .frame(width: proxy.size.width, height: proxy.size.height)


### PR DESCRIPTION
Resolves "can we add a toggle to hide the bottom player thingy?" — with the chevron arrow you asked for, sliding down and back up.

## Behavior

- New `chevron.down` button in the top toolbar (leftmost of the toolbar trailing group). Tap it and the whole control stack — scrubber, time, action row, transport row, patterns — slides down off the screen with a fade. Chevron flips to `chevron.up`, tinted accent, signaling "tap to bring them back."
- The video then fills all the way down to the home indicator.

## Pause without bringing controls back

Without it, focus mode would be annoying — pause means re-show the controls, tap pause, re-hide. So **single-tap on the video** now toggles play/pause. Double-tap to zoom still works: SwiftUI's tap-gesture disambiguation handles the timing automatically (slight delay on single-tap so it can detect a second tap).

Single-tap is wired regardless of focus mode — it's just a generally useful gesture.

## Implementation notes

- `ZoomablePlayerContainer` gets an optional `onSingleTap: (() -> Void)?` parameter.
- `controlsHidden` is `@State`, not `@AppStorage` — a per-session choice. Defaulting a fresh clip to "no controls visible" would be confusing.
- Slide-down transition is `.move(edge: .bottom).combined(with: .opacity)` so the controls feel anchored to the bottom edge. Opacity-only swap pops; height collapse without translation reads as a glitch.

## Tests

93/93. No new tests — animation + chrome.
