### PR TITLE
Source-clip body pose detection (#71)

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -15,13 +15,16 @@
 		2B90619AE0B5262B774DEAC1 /* PracticeControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35987D9825155E131A40950 /* PracticeControls.swift */; };
 		3D990657ED52C04DBB04687A /* NowPlayingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46242480BEBB0CDD9B45F158 /* NowPlayingController.swift */; };
 		4181110140BD581DBFB0A380 /* StepTimingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3B8C1BB7ACE2D1C13C7200 /* StepTimingTests.swift */; };
+		52562CC7EBC717613965ADAB /* PoseStreamCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5844567C104B87D338953E6 /* PoseStreamCoordinator.swift */; };
 		527B9B596B00D2C774173ECA /* PracticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35AE6C8D6564306E1B0ADA20 /* PracticeView.swift */; };
 		5F405BD1B2F2EB7F30970683 /* LibraryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */; };
 		622A6663058E88A57B465B62 /* StepTiming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0265ABC8E91AF4657EB95F83 /* StepTiming.swift */; };
 		648013A1A4C23692CD6ED03B /* OriginalImportServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF4094CC2957462A284F735A /* OriginalImportServiceTests.swift */; };
 		691A3AE86C110C252A1412FE /* BeatGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078CB839E392E788201DD665 /* BeatGrid.swift */; };
+		6BEA9ED6D92F4B26B85BFA21 /* PoseDetectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D718DA7FBF3C3F0248929A7 /* PoseDetectionService.swift */; };
 		72A012D3DCF8FA13D69C1868 /* KeepScreenAwake.swift in Sources */ = {isa = PBXBuildFile; fileRef = E56B6CE778D3BD0C5B1B248B /* KeepScreenAwake.swift */; };
 		76D520F6EC5A0A8E57C8AAA1 /* BeatDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6BC077A9FA8B51D07C178A0 /* BeatDetectorTests.swift */; };
+		782B609F039BD291571F9CB2 /* PoseCoordinateTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75D7B3643B17B81DF4B8A3D8 /* PoseCoordinateTransform.swift */; };
 		7FA3BBA0113FDF3282819E84 /* PracticePlayerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */; };
 		8772C73FA1983B9E8A39FAD8 /* Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5445312DC1A378A65F963DD7 /* Schema.swift */; };
 		9799CACB6C924AC1940D9FE3 /* StepBackMigrationPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808127290713ACE9855DA35E /* StepBackMigrationPlanTests.swift */; };
@@ -39,6 +42,7 @@
 		C97E59DA25A51E16ECA03607 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C112AEA59633E85CF8267D /* ThemeTests.swift */; };
 		CBA5E26E730D69F9A3E4944B /* TrimAnnotationShifter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71643D36F7F8D028B560F012 /* TrimAnnotationShifter.swift */; };
 		CC6F98E7716925F88449689A /* PhotosServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */; };
+		D59006BDF41C10B002F97FE8 /* PoseOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08505D0FA11E6637197AF8EC /* PoseOverlay.swift */; };
 		D8739042EECB4AE2C7804C41 /* OriginalImportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D1395E84111ADD80CC22565 /* OriginalImportService.swift */; };
 		D9873262DD68100D8D3C1021 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 462E264B215595E9EC3D1C4A /* Assets.xcassets */; };
 		DA0EE94353A18DA75824D7A8 /* BeatGridTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7093A077C0A2C139BD7BDD29 /* BeatGridTests.swift */; };
@@ -46,6 +50,7 @@
 		E9E06DF791FF47015B3DDFA8 /* BeatDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59BD8F65AE46261EEFD4F69 /* BeatDetector.swift */; };
 		F35848C14CA3DF06A4EBE554 /* SpeedFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E676751B59ED083837CE39 /* SpeedFormatterTests.swift */; };
 		F7AD3FACE8B875F1C9DFA310 /* PhotosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F8476EAB523378C1F1E046 /* PhotosService.swift */; };
+		FF149265E884C202BEF590BE /* PoseCoordinateTransformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED02929698766149F5A683B1 /* PoseCoordinateTransformTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -62,6 +67,7 @@
 		023608F63978F9D1668F5AFC /* StepBackApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepBackApp.swift; sourceTree = "<group>"; };
 		0265ABC8E91AF4657EB95F83 /* StepTiming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepTiming.swift; sourceTree = "<group>"; };
 		078CB839E392E788201DD665 /* BeatGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeatGrid.swift; sourceTree = "<group>"; };
+		08505D0FA11E6637197AF8EC /* PoseOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoseOverlay.swift; sourceTree = "<group>"; };
 		0C54B956DF5DE01C00D95680 /* AutoTagServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoTagServiceTests.swift; sourceTree = "<group>"; };
 		16E676751B59ED083837CE39 /* SpeedFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedFormatterTests.swift; sourceTree = "<group>"; };
 		2D07843122196F5F0DA539D1 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
@@ -74,10 +80,12 @@
 		5445312DC1A378A65F963DD7 /* Schema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Schema.swift; sourceTree = "<group>"; };
 		56E94F050959741028A8574D /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		57317F752B65258CB2D04530 /* LoopEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopEvaluatorTests.swift; sourceTree = "<group>"; };
+		5D718DA7FBF3C3F0248929A7 /* PoseDetectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoseDetectionService.swift; sourceTree = "<group>"; };
 		6745FF48B10D28A5ED4BB568 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
 		6BCED6C8E1CE7A48B341C8B1 /* TrimExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimExportService.swift; sourceTree = "<group>"; };
 		7093A077C0A2C139BD7BDD29 /* BeatGridTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeatGridTests.swift; sourceTree = "<group>"; };
 		71643D36F7F8D028B560F012 /* TrimAnnotationShifter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimAnnotationShifter.swift; sourceTree = "<group>"; };
+		75D7B3643B17B81DF4B8A3D8 /* PoseCoordinateTransform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoseCoordinateTransform.swift; sourceTree = "<group>"; };
 		808127290713ACE9855DA35E /* StepBackMigrationPlanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepBackMigrationPlanTests.swift; sourceTree = "<group>"; };
 		848D52E156E709AA0226CEE8 /* ModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsTests.swift; sourceTree = "<group>"; };
 		8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryFormatterTests.swift; sourceTree = "<group>"; };
@@ -87,6 +95,7 @@
 		94AAA488969D7CF77497859D /* SegmentThumbnailGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentThumbnailGenerator.swift; sourceTree = "<group>"; };
 		99CA1B5B91B8D4637FEEF872 /* AutoTagService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoTagService.swift; sourceTree = "<group>"; };
 		A3776C829FB11907CC7E87F9 /* StepBack.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = StepBack.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A5844567C104B87D338953E6 /* PoseStreamCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoseStreamCoordinator.swift; sourceTree = "<group>"; };
 		AAB30650146433E889DC2AF4 /* LibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryView.swift; sourceTree = "<group>"; };
 		AC399CE513ADED3ED5394848 /* ZoomablePlayerContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomablePlayerContainer.swift; sourceTree = "<group>"; };
 		B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosServiceTests.swift; sourceTree = "<group>"; };
@@ -99,6 +108,7 @@
 		E56B6CE778D3BD0C5B1B248B /* KeepScreenAwake.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeepScreenAwake.swift; sourceTree = "<group>"; };
 		EAF9D9B68E730BA51C86D70A /* TrimView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimView.swift; sourceTree = "<group>"; };
 		EB991AFC28C64366954E1D19 /* TrimAnnotationShifterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimAnnotationShifterTests.swift; sourceTree = "<group>"; };
+		ED02929698766149F5A683B1 /* PoseCoordinateTransformTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoseCoordinateTransformTests.swift; sourceTree = "<group>"; };
 		EF4094CC2957462A284F735A /* OriginalImportServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OriginalImportServiceTests.swift; sourceTree = "<group>"; };
 		F6BC077A9FA8B51D07C178A0 /* BeatDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeatDetectorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -128,6 +138,7 @@
 				8D25E6771271EDD5B867F61E /* ClipEditView.swift */,
 				92D24FDCCE45AEFB352C5EBF /* CompareView.swift */,
 				AAB30650146433E889DC2AF4 /* LibraryView.swift */,
+				08505D0FA11E6637197AF8EC /* PoseOverlay.swift */,
 				CC6BAE20433D2ED45F00AD41 /* PracticeBeatUI.swift */,
 				C35987D9825155E131A40950 /* PracticeControls.swift */,
 				35AE6C8D6564306E1B0ADA20 /* PracticeView.swift */,
@@ -149,6 +160,7 @@
 				848D52E156E709AA0226CEE8 /* ModelsTests.swift */,
 				EF4094CC2957462A284F735A /* OriginalImportServiceTests.swift */,
 				B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */,
+				ED02929698766149F5A683B1 /* PoseCoordinateTransformTests.swift */,
 				16E676751B59ED083837CE39 /* SpeedFormatterTests.swift */,
 				808127290713ACE9855DA35E /* StepBackMigrationPlanTests.swift */,
 				DB3B8C1BB7ACE2D1C13C7200 /* StepTimingTests.swift */,
@@ -167,6 +179,9 @@
 				46242480BEBB0CDD9B45F158 /* NowPlayingController.swift */,
 				4D1395E84111ADD80CC22565 /* OriginalImportService.swift */,
 				D8F8476EAB523378C1F1E046 /* PhotosService.swift */,
+				75D7B3643B17B81DF4B8A3D8 /* PoseCoordinateTransform.swift */,
+				5D718DA7FBF3C3F0248929A7 /* PoseDetectionService.swift */,
+				A5844567C104B87D338953E6 /* PoseStreamCoordinator.swift */,
 				543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */,
 				94AAA488969D7CF77497859D /* SegmentThumbnailGenerator.swift */,
 				0265ABC8E91AF4657EB95F83 /* StepTiming.swift */,
@@ -315,6 +330,10 @@
 				3D990657ED52C04DBB04687A /* NowPlayingController.swift in Sources */,
 				D8739042EECB4AE2C7804C41 /* OriginalImportService.swift in Sources */,
 				F7AD3FACE8B875F1C9DFA310 /* PhotosService.swift in Sources */,
+				782B609F039BD291571F9CB2 /* PoseCoordinateTransform.swift in Sources */,
+				6BEA9ED6D92F4B26B85BFA21 /* PoseDetectionService.swift in Sources */,
+				D59006BDF41C10B002F97FE8 /* PoseOverlay.swift in Sources */,
+				52562CC7EBC717613965ADAB /* PoseStreamCoordinator.swift in Sources */,
 				03C973FD27336E9DD2EDE507 /* PracticeBeatUI.swift in Sources */,
 				2B90619AE0B5262B774DEAC1 /* PracticeControls.swift in Sources */,
 				7FA3BBA0113FDF3282819E84 /* PracticePlayerViewModel.swift in Sources */,
@@ -344,6 +363,7 @@
 				C376AB20647940A9E53A89D0 /* ModelsTests.swift in Sources */,
 				648013A1A4C23692CD6ED03B /* OriginalImportServiceTests.swift in Sources */,
 				CC6F98E7716925F88449689A /* PhotosServiceTests.swift in Sources */,
+				FF149265E884C202BEF590BE /* PoseCoordinateTransformTests.swift in Sources */,
 				F35848C14CA3DF06A4EBE554 /* SpeedFormatterTests.swift in Sources */,
 				9799CACB6C924AC1940D9FE3 /* StepBackMigrationPlanTests.swift in Sources */,
 				4181110140BD581DBFB0A380 /* StepTimingTests.swift in Sources */,

--- a/StepBack/Services/PoseCoordinateTransform.swift
+++ b/StepBack/Services/PoseCoordinateTransform.swift
@@ -1,0 +1,50 @@
+import CoreGraphics
+
+/// Pure geometry helpers shared by `PoseOverlay` and any future pose surface.
+/// Kept independent of SwiftUI / AVFoundation so the math is unit-testable
+/// without a player or a view.
+enum PoseCoordinateTransform {
+
+    /// The rect occupied by a source image inside a container when fit
+    /// aspect-correct — i.e. exactly what `AVPlayerLayer` does with
+    /// `.videoGravity = .resizeAspect`. Letterboxes top/bottom for sources
+    /// wider than the container, left/right for taller sources.
+    ///
+    /// Returns `.zero` for any zero dimension; the overlay treats this as
+    /// "no joints to draw" and renders nothing.
+    static func displayRect(
+        imageSize: CGSize,
+        in containerSize: CGSize
+    ) -> CGRect {
+        guard imageSize.width > 0, imageSize.height > 0,
+              containerSize.width > 0, containerSize.height > 0 else {
+            return .zero
+        }
+        let imageAspect = imageSize.width / imageSize.height
+        let containerAspect = containerSize.width / containerSize.height
+        if imageAspect > containerAspect {
+            // Source is wider than the container: fit width, letterbox top/bottom.
+            let height = containerSize.width / imageAspect
+            let y = (containerSize.height - height) / 2
+            return CGRect(x: 0, y: y, width: containerSize.width, height: height)
+        } else {
+            // Source is taller (or equal): fit height, letterbox left/right.
+            let width = containerSize.height * imageAspect
+            let x = (containerSize.width - width) / 2
+            return CGRect(x: x, y: 0, width: width, height: containerSize.height)
+        }
+    }
+
+    /// Maps a Vision-space point (normalized 0…1, origin bottom-left) into
+    /// view space (top-left origin) using the display rect from
+    /// `displayRect(imageSize:in:)`. The Y axis is flipped to match SwiftUI.
+    static func viewPoint(
+        normalizedImagePoint: CGPoint,
+        displayRect: CGRect
+    ) -> CGPoint {
+        CGPoint(
+            x: displayRect.minX + normalizedImagePoint.x * displayRect.width,
+            y: displayRect.minY + (1 - normalizedImagePoint.y) * displayRect.height
+        )
+    }
+}

--- a/StepBack/Services/PoseDetectionService.swift
+++ b/StepBack/Services/PoseDetectionService.swift
@@ -1,0 +1,78 @@
+import CoreGraphics
+import CoreVideo
+import Foundation
+import Vision
+
+/// A single body joint detected by Vision in a frame.
+struct DetectedJoint: Equatable, Sendable {
+    let name: VNHumanBodyPoseObservation.JointName
+    /// Vision coordinates: normalized 0…1, origin bottom-left of the image.
+    let normalizedPosition: CGPoint
+    let confidence: Float
+}
+
+/// One person's pose as a collection of joints above the confidence floor.
+/// We intentionally don't model multiple people in v1 — the practice surface
+/// is dancer-focused and grabbing the most-confident observation is enough
+/// to verify the pipeline is working.
+struct DetectedPose: Equatable, Sendable {
+    let joints: [DetectedJoint]
+}
+
+enum PoseDetectionError: Error, LocalizedError {
+    case visionFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .visionFailed(let detail): "Pose detection failed: \(detail)"
+        }
+    }
+}
+
+/// Synchronous, Sendable Vision wrapper. Callers run it on a background
+/// queue — `VNImageRequestHandler.perform(_:)` is blocking and can take
+/// 10–30ms per frame on recent iPhones, more on older hardware.
+struct PoseDetectionService: Sendable {
+
+    /// Joints below this confidence are dropped. 0.3 is Apple's documented
+    /// "reasonably reliable" floor for 2D body pose; lower than that and
+    /// the overlay starts dancing around on hands/feet.
+    let confidenceThreshold: Float
+
+    init(confidenceThreshold: Float = 0.3) {
+        self.confidenceThreshold = confidenceThreshold
+    }
+
+    func detect(
+        in pixelBuffer: CVPixelBuffer,
+        orientation: CGImagePropertyOrientation = .up
+    ) throws -> DetectedPose? {
+        let request = VNDetectHumanBodyPoseRequest()
+        let handler = VNImageRequestHandler(
+            cvPixelBuffer: pixelBuffer,
+            orientation: orientation,
+            options: [:]
+        )
+        do {
+            try handler.perform([request])
+        } catch {
+            throw PoseDetectionError.visionFailed(error.localizedDescription)
+        }
+        guard let observation = (request.results ?? []).first else { return nil }
+        let allPoints: [VNHumanBodyPoseObservation.JointName: VNRecognizedPoint]
+        do {
+            allPoints = try observation.recognizedPoints(.all)
+        } catch {
+            throw PoseDetectionError.visionFailed(error.localizedDescription)
+        }
+        let joints = allPoints.compactMap { (name, point) -> DetectedJoint? in
+            guard point.confidence >= confidenceThreshold else { return nil }
+            return DetectedJoint(
+                name: name,
+                normalizedPosition: point.location,
+                confidence: point.confidence
+            )
+        }
+        return joints.isEmpty ? nil : DetectedPose(joints: joints)
+    }
+}

--- a/StepBack/Services/PoseStreamCoordinator.swift
+++ b/StepBack/Services/PoseStreamCoordinator.swift
@@ -1,0 +1,142 @@
+import AVFoundation
+import Combine
+import CoreVideo
+import Foundation
+
+/// Drives pose detection against an `AVPlayer`'s currently-displayed frame.
+/// Attaches an `AVPlayerItemVideoOutput` to whatever item is current, polls
+/// every 100ms while running, and publishes the latest pose + status. The
+/// view observes those publications and draws/labels accordingly.
+@MainActor
+final class PoseStreamCoordinator: ObservableObject {
+
+    /// Dashboard-friendly summary of what the pipeline is currently doing.
+    /// `idle` = pipeline off. `waiting` = on, but no frame yet (e.g. just
+    /// flipped the toggle and the next tick hasn't fired). The chip in the
+    /// view keys off this directly.
+    enum Status: Equatable {
+        case idle
+        case waiting
+        case detected(jointCount: Int)
+        case noPerson
+        case error(String)
+    }
+
+    @Published private(set) var pose: DetectedPose?
+    @Published private(set) var status: Status = .idle
+    @Published private(set) var imageSize: CGSize?
+    @Published private(set) var isActive: Bool = false
+
+    /// 100ms tick. At 10Hz, Vision's body-pose request runs cheaply enough
+    /// to stay out of the main thread budget (work happens on
+    /// `detectionQueue`) while still feeling reactive on the overlay.
+    private static let tickInterval: Duration = .milliseconds(100)
+
+    private let player: AVPlayer
+    private let detector: PoseDetectionService
+    private let videoOutput: AVPlayerItemVideoOutput
+    private let detectionQueue = DispatchQueue(
+        label: "com.sauravpanda.stepback.pose-detection",
+        qos: .userInitiated
+    )
+    private var tickTask: Task<Void, Never>?
+
+    init(
+        player: AVPlayer,
+        detector: PoseDetectionService = PoseDetectionService()
+    ) {
+        self.player = player
+        self.detector = detector
+        videoOutput = AVPlayerItemVideoOutput(pixelBufferAttributes: [
+            kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32BGRA)
+        ])
+    }
+
+    deinit {
+        tickTask?.cancel()
+    }
+
+    func start() {
+        guard tickTask == nil else { return }
+        isActive = true
+        status = .waiting
+        pose = nil
+        attachOutputIfNeeded()
+        tickTask = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.tick()
+                try? await Task.sleep(for: Self.tickInterval)
+            }
+        }
+    }
+
+    func stop() {
+        tickTask?.cancel()
+        tickTask = nil
+        isActive = false
+        status = .idle
+        pose = nil
+        detachOutput()
+    }
+
+    // MARK: - Internals
+
+    /// AVPlayerItemVideoOutput is bound to a specific AVPlayerItem; when
+    /// the player swaps items (trim export, reload, etc.) we need to
+    /// re-attach. Cheap to call repeatedly, so the tick does it every loop.
+    private func attachOutputIfNeeded() {
+        guard let item = player.currentItem else { return }
+        if !item.outputs.contains(where: { $0 === videoOutput }) {
+            item.add(videoOutput)
+        }
+    }
+
+    private func detachOutput() {
+        if let item = player.currentItem,
+           item.outputs.contains(where: { $0 === videoOutput }) {
+            item.remove(videoOutput)
+        }
+    }
+
+    private func tick() async {
+        attachOutputIfNeeded()
+        guard player.currentItem != nil else { return }
+        let time = player.currentTime()
+        guard videoOutput.hasNewPixelBuffer(forItemTime: time) else { return }
+        guard let pixelBuffer = videoOutput.copyPixelBuffer(
+            forItemTime: time,
+            itemTimeForDisplay: nil
+        ) else { return }
+
+        if imageSize == nil {
+            imageSize = CGSize(
+                width: CVPixelBufferGetWidth(pixelBuffer),
+                height: CVPixelBufferGetHeight(pixelBuffer)
+            )
+        }
+
+        let result = await detect(pixelBuffer: pixelBuffer)
+        switch result {
+        case .success(let pose):
+            self.pose = pose
+            self.status = pose.map { .detected(jointCount: $0.joints.count) } ?? .noPerson
+        case .failure(let error):
+            self.status = .error(error.localizedDescription)
+        }
+    }
+
+    /// Runs the synchronous Vision request on `detectionQueue` and bridges
+    /// back to MainActor via a continuation. We capture `detector` by value
+    /// so the queue closure doesn't touch `self` across the actor boundary.
+    private func detect(pixelBuffer: CVPixelBuffer) async -> Result<DetectedPose?, Error> {
+        let detector = self.detector
+        return await withCheckedContinuation { continuation in
+            detectionQueue.async {
+                let outcome = Result {
+                    try detector.detect(in: pixelBuffer)
+                }
+                continuation.resume(returning: outcome)
+            }
+        }
+    }
+}

--- a/StepBack/Views/PoseOverlay.swift
+++ b/StepBack/Views/PoseOverlay.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+import Vision
+
+/// Renders a Vision body-pose skeleton over a video frame. Sized to its
+/// parent via `GeometryReader`; the parent is expected to be the same
+/// surface that displays the video at aspect-fit, so the joint coordinates
+/// land on the actual body, not on the letterboxed black area.
+struct PoseOverlay: View {
+
+    let pose: DetectedPose?
+    let imageSize: CGSize?
+
+    var body: some View {
+        GeometryReader { geo in
+            if let pose, let imageSize {
+                let rect = PoseCoordinateTransform.displayRect(
+                    imageSize: imageSize,
+                    in: geo.size
+                )
+                Canvas { context, _ in
+                    drawBones(pose: pose, displayRect: rect, context: context)
+                    drawJoints(pose: pose, displayRect: rect, context: context)
+                }
+            }
+        }
+        .allowsHitTesting(false)
+    }
+
+    private func drawBones(
+        pose: DetectedPose,
+        displayRect: CGRect,
+        context: GraphicsContext
+    ) {
+        let lookup = Dictionary(
+            uniqueKeysWithValues: pose.joints.map { ($0.name, $0) }
+        )
+        for (start, end) in Self.skeletonEdges {
+            guard let a = lookup[start], let b = lookup[end] else { continue }
+            let pa = PoseCoordinateTransform.viewPoint(
+                normalizedImagePoint: a.normalizedPosition,
+                displayRect: displayRect
+            )
+            let pb = PoseCoordinateTransform.viewPoint(
+                normalizedImagePoint: b.normalizedPosition,
+                displayRect: displayRect
+            )
+            var path = Path()
+            path.move(to: pa)
+            path.addLine(to: pb)
+            let alpha = min(CGFloat(a.confidence), CGFloat(b.confidence))
+            context.stroke(
+                path,
+                with: .color(Theme.Color.accent.opacity(alpha)),
+                lineWidth: 3
+            )
+        }
+    }
+
+    private func drawJoints(
+        pose: DetectedPose,
+        displayRect: CGRect,
+        context: GraphicsContext
+    ) {
+        for joint in pose.joints {
+            let p = PoseCoordinateTransform.viewPoint(
+                normalizedImagePoint: joint.normalizedPosition,
+                displayRect: displayRect
+            )
+            let radius: CGFloat = 4
+            let rect = CGRect(
+                x: p.x - radius,
+                y: p.y - radius,
+                width: radius * 2,
+                height: radius * 2
+            )
+            let alpha = CGFloat(joint.confidence)
+            context.fill(
+                Path(ellipseIn: rect),
+                with: .color(Theme.Color.accent.opacity(alpha))
+            )
+        }
+    }
+
+    /// Bone connections we draw. Face is omitted by default — eyes/ears
+    /// rarely have high enough confidence on dance footage and add noise.
+    /// Add them back if 3D / face detection becomes interesting later.
+    private static let skeletonEdges: [(
+        VNHumanBodyPoseObservation.JointName,
+        VNHumanBodyPoseObservation.JointName
+    )] = [
+        // torso
+        (.leftShoulder, .rightShoulder),
+        (.leftShoulder, .leftHip),
+        (.rightShoulder, .rightHip),
+        (.leftHip, .rightHip),
+        // arms
+        (.leftShoulder, .leftElbow),
+        (.leftElbow, .leftWrist),
+        (.rightShoulder, .rightElbow),
+        (.rightElbow, .rightWrist),
+        // legs
+        (.leftHip, .leftKnee),
+        (.leftKnee, .leftAnkle),
+        (.rightHip, .rightKnee),
+        (.rightKnee, .rightAnkle),
+    ]
+}
+
+/// Small chip rendered above the video when pose detection is enabled, so
+/// the dashboard can read "is this working?" at a glance without watching
+/// the overlay redraw.
+struct PoseStatusChip: View {
+    let status: PoseStreamCoordinator.Status
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(indicatorColor)
+                .frame(width: 6, height: 6)
+            Text(label)
+                .font(.system(.caption2, design: .rounded, weight: .semibold))
+                .foregroundStyle(Theme.Color.textPrimary)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Color.black.opacity(0.55), in: Capsule())
+    }
+
+    private var indicatorColor: Color {
+        switch status {
+        case .idle: Theme.Color.textTertiary
+        case .waiting: .yellow
+        case .detected: .green
+        case .noPerson: .orange
+        case .error: .red
+        }
+    }
+
+    private var label: String {
+        switch status {
+        case .idle: "Pose off"
+        case .waiting: "Detecting…"
+        case .detected(let count): "Pose · \(count) joints"
+        case .noPerson: "No person"
+        case .error(let message): "Pose: \(message)"
+        }
+    }
+}

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -20,14 +20,23 @@ struct PracticeView: View {
     /// Single-tap on the video remains wired to play/pause so pausing
     /// doesn't require bringing controls back first.
     @State private var controlsHidden: Bool = false
+    @StateObject private var poseCoordinator: PoseStreamCoordinator
 
     init(clip: DanceClip) {
         self.clip = clip
+        // Share a single AVPlayer between the view model and the pose
+        // coordinator so the coordinator's video output reads frames from
+        // the *same* item the user is watching.
+        let sharedPlayer = AVPlayer()
         _vm = StateObject(
             wrappedValue: PracticePlayerViewModel(
                 assetIdentifier: clip.assetIdentifier,
-                localFileURL: clip.preferredLocalFileURL
+                localFileURL: clip.preferredLocalFileURL,
+                player: sharedPlayer
             )
+        )
+        _poseCoordinator = StateObject(
+            wrappedValue: PoseStreamCoordinator(player: sharedPlayer)
         )
     }
 
@@ -64,6 +73,26 @@ struct PracticeView: View {
                             .foregroundStyle(Theme.Color.textPrimary)
                     }
                     .accessibilityLabel("Edit clip")
+                    Button {
+                        if poseCoordinator.isActive {
+                            poseCoordinator.stop()
+                        } else {
+                            poseCoordinator.start()
+                        }
+                    } label: {
+                        Image(systemName: poseCoordinator.isActive
+                            ? "figure.walk.motion"
+                            : "figure.walk"
+                        )
+                        .foregroundStyle(poseCoordinator.isActive
+                            ? Theme.Color.accent
+                            : Theme.Color.textPrimary
+                        )
+                    }
+                    .accessibilityLabel(poseCoordinator.isActive
+                        ? "Disable pose detection"
+                        : "Enable pose detection"
+                    )
                     Button {
                         comparePickerPresented = true
                     } label: {
@@ -104,7 +133,10 @@ struct PracticeView: View {
             configureBeatPulse()
         }
         .onAppear { vm.enableNowPlaying(for: clip) }
-        .onDisappear { vm.disableNowPlaying() }
+        .onDisappear {
+            vm.disableNowPlaying()
+            poseCoordinator.stop()
+        }
         .keepScreenAwake()
         .sheet(isPresented: $comparePickerPresented) {
             CompareClipPicker(excludedID: clip.id) { picked in
@@ -166,12 +198,31 @@ struct PracticeView: View {
                 // claim leftover vertical space; controls keep their intrinsic
                 // height and float beneath.
                 ZoomablePlayerContainer(onSingleTap: { vm.togglePlayPause() }) {
-                    PlayerSurface(player: vm.player)
-                        .scaleEffect(x: vm.mirrored ? -1 : 1, y: 1)
+                    ZStack {
+                        PlayerSurface(player: vm.player)
+                            .scaleEffect(x: vm.mirrored ? -1 : 1, y: 1)
+                        if poseCoordinator.isActive {
+                            // Mirror the overlay alongside the video so the
+                            // skeleton tracks the actual displayed body, not
+                            // the original frame's body.
+                            PoseOverlay(
+                                pose: poseCoordinator.pose,
+                                imageSize: poseCoordinator.imageSize
+                            )
+                            .scaleEffect(x: vm.mirrored ? -1 : 1, y: 1)
+                        }
+                    }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(Color.black)
                 .layoutPriority(1)
+                .overlay(alignment: .topLeading) {
+                    if poseCoordinator.isActive {
+                        PoseStatusChip(status: poseCoordinator.status)
+                            .padding(.leading, 10)
+                            .padding(.top, 10)
+                    }
+                }
 
                 if !controlsHidden {
                     controls

--- a/StepBackTests/PoseCoordinateTransformTests.swift
+++ b/StepBackTests/PoseCoordinateTransformTests.swift
@@ -1,0 +1,123 @@
+@testable import StepBack
+import CoreGraphics
+import XCTest
+
+final class PoseCoordinateTransformTests: XCTestCase {
+
+    private let accuracy: CGFloat = 0.0001
+
+    // MARK: - displayRect
+
+    func testDisplayRectMatchesContainerWhenAspectsMatch() {
+        // 16:9 image into 16:9 container → fills exactly, no letterbox.
+        let result = PoseCoordinateTransform.displayRect(
+            imageSize: CGSize(width: 1920, height: 1080),
+            in: CGSize(width: 400, height: 225)
+        )
+        XCTAssertEqual(result.origin.x, 0, accuracy: accuracy)
+        XCTAssertEqual(result.origin.y, 0, accuracy: accuracy)
+        XCTAssertEqual(result.width, 400, accuracy: accuracy)
+        XCTAssertEqual(result.height, 225, accuracy: accuracy)
+    }
+
+    func testDisplayRectLetterboxesTopAndBottomForWideImage() {
+        // 16:9 image (1.777…) into 1:1 container → fit width, letterbox y.
+        let result = PoseCoordinateTransform.displayRect(
+            imageSize: CGSize(width: 1600, height: 900),
+            in: CGSize(width: 400, height: 400)
+        )
+        XCTAssertEqual(result.origin.x, 0, accuracy: accuracy)
+        XCTAssertEqual(result.width, 400, accuracy: accuracy)
+        // height = 400 / (1600/900) = 400 / 1.777… = 225
+        XCTAssertEqual(result.height, 225, accuracy: accuracy)
+        // centered vertically: (400 - 225) / 2 = 87.5
+        XCTAssertEqual(result.origin.y, 87.5, accuracy: accuracy)
+    }
+
+    func testDisplayRectLetterboxesLeftAndRightForTallImage() {
+        // 9:16 image (0.5625) into 1:1 container → fit height, letterbox x.
+        let result = PoseCoordinateTransform.displayRect(
+            imageSize: CGSize(width: 1080, height: 1920),
+            in: CGSize(width: 400, height: 400)
+        )
+        XCTAssertEqual(result.origin.y, 0, accuracy: accuracy)
+        XCTAssertEqual(result.height, 400, accuracy: accuracy)
+        // width = 400 * (1080/1920) = 400 * 0.5625 = 225
+        XCTAssertEqual(result.width, 225, accuracy: accuracy)
+        // centered horizontally: (400 - 225) / 2 = 87.5
+        XCTAssertEqual(result.origin.x, 87.5, accuracy: accuracy)
+    }
+
+    func testDisplayRectIsZeroForZeroImage() {
+        XCTAssertEqual(
+            PoseCoordinateTransform.displayRect(
+                imageSize: .zero,
+                in: CGSize(width: 100, height: 100)
+            ),
+            .zero
+        )
+    }
+
+    func testDisplayRectIsZeroForZeroContainer() {
+        XCTAssertEqual(
+            PoseCoordinateTransform.displayRect(
+                imageSize: CGSize(width: 100, height: 100),
+                in: .zero
+            ),
+            .zero
+        )
+    }
+
+    // MARK: - viewPoint
+
+    func testViewPointAtImageOriginMapsToBottomLeftOfDisplayRect() {
+        // Vision origin (0, 0) is the bottom-left of the image. With a
+        // display rect of (10, 20)…(110, 220), bottom-left is (10, 220).
+        let rect = CGRect(x: 10, y: 20, width: 100, height: 200)
+        let result = PoseCoordinateTransform.viewPoint(
+            normalizedImagePoint: CGPoint(x: 0, y: 0),
+            displayRect: rect
+        )
+        XCTAssertEqual(result.x, 10, accuracy: accuracy)
+        XCTAssertEqual(result.y, 220, accuracy: accuracy)
+    }
+
+    func testViewPointAtTopRightOfImageMapsToTopRightOfDisplayRect() {
+        // Vision (1, 1) is the top-right; same as view top-right after flip.
+        let rect = CGRect(x: 10, y: 20, width: 100, height: 200)
+        let result = PoseCoordinateTransform.viewPoint(
+            normalizedImagePoint: CGPoint(x: 1, y: 1),
+            displayRect: rect
+        )
+        XCTAssertEqual(result.x, 110, accuracy: accuracy)
+        XCTAssertEqual(result.y, 20, accuracy: accuracy)
+    }
+
+    func testViewPointAtCenterMapsToCenter() {
+        let rect = CGRect(x: 0, y: 0, width: 400, height: 200)
+        let result = PoseCoordinateTransform.viewPoint(
+            normalizedImagePoint: CGPoint(x: 0.5, y: 0.5),
+            displayRect: rect
+        )
+        XCTAssertEqual(result.x, 200, accuracy: accuracy)
+        XCTAssertEqual(result.y, 100, accuracy: accuracy)
+    }
+
+    func testViewPointInLetterboxedDisplayRect() {
+        // 16:9 source in a 1:1 container produced a rect at y=87.5,
+        // height=225. A Vision point at (0.5, 0.5) — image center — should
+        // land at the center of *that rect*, i.e. (200, 200).
+        let imageSize = CGSize(width: 1600, height: 900)
+        let container = CGSize(width: 400, height: 400)
+        let rect = PoseCoordinateTransform.displayRect(
+            imageSize: imageSize,
+            in: container
+        )
+        let result = PoseCoordinateTransform.viewPoint(
+            normalizedImagePoint: CGPoint(x: 0.5, y: 0.5),
+            displayRect: rect
+        )
+        XCTAssertEqual(result.x, 200, accuracy: accuracy)
+        XCTAssertEqual(result.y, 200, accuracy: accuracy)
+    }
+}


### PR DESCRIPTION
Closes #71. Thin slice (a) of pose detection — source-clip only, skeleton overlay, status chip. Nothing about the user's camera or persistence yet; those are explicitly out of scope.

## What you'll see

- New `figure.walk` toggle in the top toolbar (between Edit and the new chevron). Tinted accent when on.
- When on, a small **status chip** appears in the top-left of the video — coloured dot + text:
  - 🟡 `Detecting…` — just turned on, waiting for the first frame
  - 🟢 `Pose · N joints` — N joints currently above the confidence floor
  - 🟠 `No person` — pipeline running, no body detected
  - 🔴 `Pose: …error…` — Vision returned an error
- A skeleton renders on top of the video, transformed alongside it (mirror, zoom, pan all carry the overlay along). Bone opacity follows the lower-confidence of the two joints it connects.

## Architecture

- **`PoseDetectionService`** — synchronous, `Sendable` wrapper around `VNDetectHumanBodyPoseRequest`. Confidence threshold defaults to `0.3` (Apple's documented floor before joints get unreliable).
- **`PoseStreamCoordinator`** (`@MainActor` `ObservableObject`) — attaches an `AVPlayerItemVideoOutput` to the player's current item, polls every 100ms while running, runs Vision on a dedicated background `DispatchQueue` (it's blocking), bridges back via a continuation. Detaches the output and resets state on `stop()`. Robust to player item swaps (trim export reload).
- **`PoseCoordinateTransform`** — pure aspect-fit geometry + Vision-to-SwiftUI Y-axis flip. Independent of SwiftUI / AVFoundation so it's unit-testable without a player.
- **`PoseOverlay`** — `Canvas` inside the `ZoomablePlayerContainer`'s content, so the skeleton transforms with pinch-zoom and pan automatically.
- **`PoseStatusChip`** — the at-a-glance dashboard.

## Wiring choice

The view model and the coordinator both need to reference the same `AVPlayer`. Constructed it in `PracticeView.init` and passed into both `StateObject` initializers — only path I know that gets two StateObjects to share underlying state.

## Tests

102/102 pass (was 93). 9 new `PoseCoordinateTransformTests` covering:
- Equal / wider / taller aspect ratios
- Zero-dimension inputs (graceful empty rect)
- Vision origin (bottom-left) → view top-left mapping
- Centre + top-right corner mappings
- Joint placement inside a letterboxed rect

`PoseDetectionService` and `PoseStreamCoordinator` aren't unit-tested in this PR — Vision needs a real `CVPixelBuffer` and AVPlayer needs a real item; that's integration-test territory and would require fixture video files. Will revisit if pipeline drift becomes a problem.

## Performance notes

- 100ms tick = 10Hz pose detection while running. Reasonable on iPhone 12+; older devices may want to throttle further.
- Off by default. Toggle off when not actively verifying.
- Vision request runs on background `qos: .userInitiated` queue, never touches the main thread.

## Followups (not this PR)

- Live user camera + side-by-side pose comparison (#TBD)
- Per-clip pose cache (avoid re-running on every play) (#TBD)
- 3D pose via `VNDetectHumanBodyPose3DRequest` if 2D doesn't carry (iOS 17+)
- Joint orientation-aware Vision request (currently assumes `.up`)
