### PR TITLE
Stabilize pose detection + weight-stacking colours

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -26,8 +26,10 @@
 		76D520F6EC5A0A8E57C8AAA1 /* BeatDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6BC077A9FA8B51D07C178A0 /* BeatDetectorTests.swift */; };
 		782B609F039BD291571F9CB2 /* PoseCoordinateTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75D7B3643B17B81DF4B8A3D8 /* PoseCoordinateTransform.swift */; };
 		7FA3BBA0113FDF3282819E84 /* PracticePlayerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */; };
+		852871D2A9B846C1A484DD59 /* WeightStackingEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90EF44647A178F72AF7CEBDB /* WeightStackingEvaluator.swift */; };
 		8772C73FA1983B9E8A39FAD8 /* Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5445312DC1A378A65F963DD7 /* Schema.swift */; };
 		9799CACB6C924AC1940D9FE3 /* StepBackMigrationPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808127290713ACE9855DA35E /* StepBackMigrationPlanTests.swift */; };
+		9955BF32B7DB538849A77F77 /* WeightStackingEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F2A8FB404F08A50DABD0B /* WeightStackingEvaluatorTests.swift */; };
 		9DCAAD9B2DCFAEE83A9D4879 /* TrimView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF9D9B68E730BA51C86D70A /* TrimView.swift */; };
 		9F90D5641396A9BF3E7A09FE /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E94F050959741028A8574D /* RootView.swift */; };
 		A49A15759EECD46EC5E3A694 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D07843122196F5F0DA539D1 /* Theme.swift */; };
@@ -78,6 +80,7 @@
 		4D1395E84111ADD80CC22565 /* OriginalImportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OriginalImportService.swift; sourceTree = "<group>"; };
 		543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticePlayerViewModel.swift; sourceTree = "<group>"; };
 		5445312DC1A378A65F963DD7 /* Schema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Schema.swift; sourceTree = "<group>"; };
+		562F2A8FB404F08A50DABD0B /* WeightStackingEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightStackingEvaluatorTests.swift; sourceTree = "<group>"; };
 		56E94F050959741028A8574D /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		57317F752B65258CB2D04530 /* LoopEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopEvaluatorTests.swift; sourceTree = "<group>"; };
 		5D718DA7FBF3C3F0248929A7 /* PoseDetectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoseDetectionService.swift; sourceTree = "<group>"; };
@@ -91,6 +94,7 @@
 		8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryFormatterTests.swift; sourceTree = "<group>"; };
 		8D25E6771271EDD5B867F61E /* ClipEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipEditView.swift; sourceTree = "<group>"; };
 		90115F7F368CDD3B0832B3B3 /* Generated-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Generated-Info.plist"; sourceTree = "<group>"; };
+		90EF44647A178F72AF7CEBDB /* WeightStackingEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightStackingEvaluator.swift; sourceTree = "<group>"; };
 		92D24FDCCE45AEFB352C5EBF /* CompareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompareView.swift; sourceTree = "<group>"; };
 		94AAA488969D7CF77497859D /* SegmentThumbnailGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentThumbnailGenerator.swift; sourceTree = "<group>"; };
 		99CA1B5B91B8D4637FEEF872 /* AutoTagService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoTagService.swift; sourceTree = "<group>"; };
@@ -166,6 +170,7 @@
 				DB3B8C1BB7ACE2D1C13C7200 /* StepTimingTests.swift */,
 				B7C112AEA59633E85CF8267D /* ThemeTests.swift */,
 				EB991AFC28C64366954E1D19 /* TrimAnnotationShifterTests.swift */,
+				562F2A8FB404F08A50DABD0B /* WeightStackingEvaluatorTests.swift */,
 			);
 			path = StepBackTests;
 			sourceTree = "<group>";
@@ -187,6 +192,7 @@
 				0265ABC8E91AF4657EB95F83 /* StepTiming.swift */,
 				71643D36F7F8D028B560F012 /* TrimAnnotationShifter.swift */,
 				6BCED6C8E1CE7A48B341C8B1 /* TrimExportService.swift */,
+				90EF44647A178F72AF7CEBDB /* WeightStackingEvaluator.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -347,6 +353,7 @@
 				CBA5E26E730D69F9A3E4944B /* TrimAnnotationShifter.swift in Sources */,
 				E709F2C42DEFD624E08A9C35 /* TrimExportService.swift in Sources */,
 				9DCAAD9B2DCFAEE83A9D4879 /* TrimView.swift in Sources */,
+				852871D2A9B846C1A484DD59 /* WeightStackingEvaluator.swift in Sources */,
 				C7DD824378246BBC211824D8 /* ZoomablePlayerContainer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -369,6 +376,7 @@
 				4181110140BD581DBFB0A380 /* StepTimingTests.swift in Sources */,
 				C97E59DA25A51E16ECA03607 /* ThemeTests.swift in Sources */,
 				AB9467B4E5F44BFF1AA916B1 /* TrimAnnotationShifterTests.swift in Sources */,
+				9955BF32B7DB538849A77F77 /* WeightStackingEvaluatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/StepBack/Services/PoseDetectionService.swift
+++ b/StepBack/Services/PoseDetectionService.swift
@@ -34,12 +34,14 @@ enum PoseDetectionError: Error, LocalizedError {
 /// 10–30ms per frame on recent iPhones, more on older hardware.
 struct PoseDetectionService: Sendable {
 
-    /// Joints below this confidence are dropped. 0.3 is Apple's documented
-    /// "reasonably reliable" floor for 2D body pose; lower than that and
-    /// the overlay starts dancing around on hands/feet.
+    /// Joints below this confidence are dropped. Apple's documented
+    /// "reasonably reliable" floor is 0.3; we use 0.25 so dance footage
+    /// — where wrists and ankles routinely sit just under 0.3 during
+    /// transitions — keeps producing usable skeletons instead of flickering.
+    /// Below 0.2 hands start drifting visibly; that's the real floor.
     let confidenceThreshold: Float
 
-    init(confidenceThreshold: Float = 0.3) {
+    init(confidenceThreshold: Float = 0.25) {
         self.confidenceThreshold = confidenceThreshold
     }
 

--- a/StepBack/Services/PoseStreamCoordinator.swift
+++ b/StepBack/Services/PoseStreamCoordinator.swift
@@ -26,11 +26,20 @@ final class PoseStreamCoordinator: ObservableObject {
     @Published private(set) var status: Status = .idle
     @Published private(set) var imageSize: CGSize?
     @Published private(set) var isActive: Bool = false
+    /// Seconds since the most recent *successful* detection. Used by the
+    /// overlay to fade the skeleton from solid (fresh) to transparent
+    /// (about-to-be-cleared) so the dashboard can see when we're holding a
+    /// stale frame vs reading the current one.
+    @Published private(set) var poseAge: TimeInterval = .infinity
 
     /// 100ms tick. At 10Hz, Vision's body-pose request runs cheaply enough
     /// to stay out of the main thread budget (work happens on
     /// `detectionQueue`) while still feeling reactive on the overlay.
     private static let tickInterval: Duration = .milliseconds(100)
+    /// Last successful pose stays visible for this long after detection
+    /// starts failing. Bridges the flicker when Vision drops a frame or
+    /// two on hard footage (motion blur, partial occlusion, etc).
+    private static let staleAfter: TimeInterval = 0.5
 
     private let player: AVPlayer
     private let detector: PoseDetectionService
@@ -40,6 +49,8 @@ final class PoseStreamCoordinator: ObservableObject {
         qos: .userInitiated
     )
     private var tickTask: Task<Void, Never>?
+    private var lastSuccessTime: Date?
+    private var lastProcessedTime: CMTime?
 
     init(
         player: AVPlayer,
@@ -61,6 +72,9 @@ final class PoseStreamCoordinator: ObservableObject {
         isActive = true
         status = .waiting
         pose = nil
+        lastSuccessTime = nil
+        lastProcessedTime = nil
+        poseAge = .infinity
         attachOutputIfNeeded()
         tickTask = Task { [weak self] in
             while !Task.isCancelled {
@@ -76,6 +90,9 @@ final class PoseStreamCoordinator: ObservableObject {
         isActive = false
         status = .idle
         pose = nil
+        lastSuccessTime = nil
+        lastProcessedTime = nil
+        poseAge = .infinity
         detachOutput()
     }
 
@@ -102,11 +119,30 @@ final class PoseStreamCoordinator: ObservableObject {
         attachOutputIfNeeded()
         guard player.currentItem != nil else { return }
         let time = player.currentTime()
-        guard videoOutput.hasNewPixelBuffer(forItemTime: time) else { return }
+
+        // Re-run detection if a new buffer is ready (playing) *or* the
+        // current time changed since last process (the user scrubbed or
+        // pause-stepped). Without the second condition, paused frames
+        // would never get re-detected after a seek.
+        let timeAdvanced: Bool = {
+            guard let last = lastProcessedTime else { return true }
+            return abs(CMTimeGetSeconds(time) - CMTimeGetSeconds(last)) > 0.01
+        }()
+        let hasNewBuffer = videoOutput.hasNewPixelBuffer(forItemTime: time)
+        guard hasNewBuffer || timeAdvanced else {
+            updatePoseAge()
+            ageOutIfStale()
+            return
+        }
         guard let pixelBuffer = videoOutput.copyPixelBuffer(
             forItemTime: time,
             itemTimeForDisplay: nil
-        ) else { return }
+        ) else {
+            updatePoseAge()
+            ageOutIfStale()
+            return
+        }
+        lastProcessedTime = time
 
         if imageSize == nil {
             imageSize = CGSize(
@@ -117,11 +153,54 @@ final class PoseStreamCoordinator: ObservableObject {
 
         let result = await detect(pixelBuffer: pixelBuffer)
         switch result {
-        case .success(let pose):
-            self.pose = pose
-            self.status = pose.map { .detected(jointCount: $0.joints.count) } ?? .noPerson
+        case .success(let detected):
+            if let detected {
+                self.pose = detected
+                self.lastSuccessTime = Date()
+                self.poseAge = 0
+                self.status = .detected(jointCount: detected.joints.count)
+            } else {
+                // Vision returned no observation — the dancer might have
+                // turned away, gone partially off-screen, or the frame's
+                // hard. Don't immediately clear the skeleton; hold for up
+                // to `staleAfter` so a single bad frame doesn't flicker.
+                handleMissedDetection(reason: .noPerson)
+            }
         case .failure(let error):
-            self.status = .error(error.localizedDescription)
+            handleMissedDetection(reason: .error(error.localizedDescription))
+        }
+    }
+
+    /// Keeps the last successful pose visible until it's older than
+    /// `staleAfter`. After that, clears it and surfaces the miss reason.
+    private func handleMissedDetection(reason: Status) {
+        updatePoseAge()
+        if poseAge > Self.staleAfter {
+            pose = nil
+            status = reason
+        }
+        // Otherwise: keep showing the prior pose, leave status as it was —
+        // the overlay's fade-by-age makes the staleness visible without
+        // flickering the dashboard chip back and forth.
+    }
+
+    /// Called every tick whether we re-ran detection or not, so the view
+    /// can fade the overlay smoothly between ticks.
+    private func updatePoseAge() {
+        guard let last = lastSuccessTime else {
+            poseAge = .infinity
+            return
+        }
+        poseAge = Date().timeIntervalSince(last)
+    }
+
+    /// When we skip detection (no new buffer, no scrub), we still want
+    /// stale poses to age out — otherwise the last pose would linger
+    /// indefinitely on a perfectly paused frame.
+    private func ageOutIfStale() {
+        if poseAge > Self.staleAfter, pose != nil {
+            pose = nil
+            status = .noPerson
         }
     }
 

--- a/StepBack/Services/WeightStackingEvaluator.swift
+++ b/StepBack/Services/WeightStackingEvaluator.swift
@@ -1,0 +1,62 @@
+import CoreGraphics
+import Foundation
+
+/// Geometric scoring for how well an individual body segment supports a
+/// stacked, balanced posture. Pure logic, no view dependencies — tested
+/// directly in `WeightStackingEvaluatorTests`.
+///
+/// We deliberately don't try to identify the "posted" (weight-bearing)
+/// foot here. That requires temporal tracking — which foot has been
+/// stationary, how long, which side the centre of mass is currently over —
+/// and lands cleanly in a v2 that buffers frames. For v1 we colour each
+/// bone against a *static* reference: legs and torso want to be vertical,
+/// hip and shoulder lines want to be level. A dancer mid-step will see
+/// bones flash red and that's correct — they're not stacked, they're in
+/// motion. Holding a balanced position will paint everything green.
+enum WeightStackingEvaluator {
+
+    /// What axis a bone should align with when the body is stacked.
+    enum PreferredAxis: Equatable {
+        /// Legs, torso sides — vertical when stacked.
+        case vertical
+        /// Shoulder and hip lines — horizontal when stacked.
+        case horizontal
+        /// Arms and other freely-moving segments — always full credit.
+        case neutral
+    }
+
+    /// 0.0 = wildly off-axis, 1.0 = perfectly aligned. Score curve is
+    /// linear in angle: 0° → 1.0, 22.5° → 0.5, 45° → 0. A 45° miss is the
+    /// floor — anything past that just stays red.
+    ///
+    /// Degenerate input (zero-length bone) returns 1.0 rather than NaN
+    /// or 0; the most graceful thing for the overlay is to render it as
+    /// "fine" and let the next frame's better data dominate.
+    static func alignmentScore(
+        from start: CGPoint,
+        to end: CGPoint,
+        axis: PreferredAxis
+    ) -> Double {
+        if axis == .neutral { return 1.0 }
+        let dx = Double(end.x - start.x)
+        let dy = Double(end.y - start.y)
+        let length = (dx * dx + dy * dy).squareRoot()
+        guard length > 0 else { return 1.0 }
+
+        let alongAxis: Double
+        switch axis {
+        case .vertical:
+            alongAxis = abs(dy) / length
+        case .horizontal:
+            alongAxis = abs(dx) / length
+        case .neutral:
+            return 1.0
+        }
+        // Clamp to [0, 1] before acos — floating-point drift can produce
+        // 1.0000000001 which would crash acos with NaN.
+        let clamped = min(1.0, max(0.0, alongAxis))
+        let angleFromAxis = acos(clamped)
+        let threshold: Double = .pi / 4   // 45° = full red
+        return max(0, 1.0 - angleFromAxis / threshold)
+    }
+}

--- a/StepBack/Views/PoseOverlay.swift
+++ b/StepBack/Views/PoseOverlay.swift
@@ -1,14 +1,44 @@
 import SwiftUI
 import Vision
 
+/// A bone in the rendered skeleton, plus what its "stacked" reference
+/// axis is. Legs and torso sides want to be vertical; the hip and shoulder
+/// lines want to be level. Arms are neutral — they fly around in dance and
+/// scoring them against an axis would just paint them red constantly.
+private struct SkeletonBone {
+    let start: VNHumanBodyPoseObservation.JointName
+    let end: VNHumanBodyPoseObservation.JointName
+    let axis: WeightStackingEvaluator.PreferredAxis
+}
+
 /// Renders a Vision body-pose skeleton over a video frame. Sized to its
 /// parent via `GeometryReader`; the parent is expected to be the same
 /// surface that displays the video at aspect-fit, so the joint coordinates
 /// land on the actual body, not on the letterboxed black area.
+///
+/// Bone colour reflects weight-stacking alignment: green when the segment
+/// is close to its preferred reference axis, fading through yellow to red
+/// as the dancer leaves a balanced position. Arms are left accent-coloured
+/// because their orientation isn't a stacking signal.
+///
+/// `poseAge` drives an overall opacity so the user can see when the
+/// skeleton being shown is the *current* detection vs one we're holding
+/// from a few frames ago (Vision dropped them) — solid = fresh, faded =
+/// almost stale.
 struct PoseOverlay: View {
 
     let pose: DetectedPose?
     let imageSize: CGSize?
+    /// Seconds since the last successful detection. The coordinator caps
+    /// this at `staleAfter` (0.5s) before clearing `pose`.
+    var poseAge: TimeInterval = 0
+
+    /// Fade ramp parameters. Below `fadeStart` the skeleton is fully solid
+    /// — every fresh detection looks the same. Past it we ramp linearly to
+    /// 0 alpha at `fadeEnd`, which should match the coordinator's stale
+    /// cutoff so a soon-to-be-cleared skeleton visibly fades before vanishing.
+    private static let fadeStart: TimeInterval = 0.2
+    private static let fadeEnd: TimeInterval = 0.5
 
     var body: some View {
         GeometryReader { geo in
@@ -21,9 +51,16 @@ struct PoseOverlay: View {
                     drawBones(pose: pose, displayRect: rect, context: context)
                     drawJoints(pose: pose, displayRect: rect, context: context)
                 }
+                .opacity(freshnessOpacity)
             }
         }
         .allowsHitTesting(false)
+    }
+
+    private var freshnessOpacity: Double {
+        if poseAge <= Self.fadeStart { return 1.0 }
+        if poseAge >= Self.fadeEnd { return 0.0 }
+        return 1.0 - (poseAge - Self.fadeStart) / (Self.fadeEnd - Self.fadeStart)
     }
 
     private func drawBones(
@@ -34,8 +71,8 @@ struct PoseOverlay: View {
         let lookup = Dictionary(
             uniqueKeysWithValues: pose.joints.map { ($0.name, $0) }
         )
-        for (start, end) in Self.skeletonEdges {
-            guard let a = lookup[start], let b = lookup[end] else { continue }
+        for bone in Self.skeleton {
+            guard let a = lookup[bone.start], let b = lookup[bone.end] else { continue }
             let pa = PoseCoordinateTransform.viewPoint(
                 normalizedImagePoint: a.normalizedPosition,
                 displayRect: displayRect
@@ -44,13 +81,23 @@ struct PoseOverlay: View {
                 normalizedImagePoint: b.normalizedPosition,
                 displayRect: displayRect
             )
+            // Stacking score → bone colour. Arms (axis: .neutral) come back
+            // 1.0 → green; that reads as "no problem here," which matches
+            // the intent (we're not making a claim about arms).
+            let score = WeightStackingEvaluator.alignmentScore(
+                from: pa, to: pb, axis: bone.axis
+            )
+            let tint = Color.stackingColor(for: score)
             var path = Path()
             path.move(to: pa)
             path.addLine(to: pb)
-            let alpha = min(CGFloat(a.confidence), CGFloat(b.confidence))
+            // Stroke alpha still tracks joint confidence so a wobbly
+            // detection visibly weakens — but the hue carries the stacking
+            // story regardless.
+            let confidenceAlpha = min(CGFloat(a.confidence), CGFloat(b.confidence))
             context.stroke(
                 path,
-                with: .color(Theme.Color.accent.opacity(alpha)),
+                with: .color(tint.opacity(confidenceAlpha)),
                 lineWidth: 3
             )
         }
@@ -74,36 +121,65 @@ struct PoseOverlay: View {
                 height: radius * 2
             )
             let alpha = CGFloat(joint.confidence)
+            // Joints stay white-ish so they read as anatomical landmarks
+            // regardless of the surrounding bone colour. Confidence still
+            // drives alpha — low-confidence joints dim out.
             context.fill(
                 Path(ellipseIn: rect),
-                with: .color(Theme.Color.accent.opacity(alpha))
+                with: .color(Color.white.opacity(alpha * 0.85))
             )
         }
     }
 
-    /// Bone connections we draw. Face is omitted by default — eyes/ears
-    /// rarely have high enough confidence on dance footage and add noise.
-    /// Add them back if 3D / face detection becomes interesting later.
-    private static let skeletonEdges: [(
-        VNHumanBodyPoseObservation.JointName,
-        VNHumanBodyPoseObservation.JointName
-    )] = [
-        // torso
-        (.leftShoulder, .rightShoulder),
-        (.leftShoulder, .leftHip),
-        (.rightShoulder, .rightHip),
-        (.leftHip, .rightHip),
-        // arms
-        (.leftShoulder, .leftElbow),
-        (.leftElbow, .leftWrist),
-        (.rightShoulder, .rightElbow),
-        (.rightElbow, .rightWrist),
-        // legs
-        (.leftHip, .leftKnee),
-        (.leftKnee, .leftAnkle),
-        (.rightHip, .rightKnee),
-        (.rightKnee, .rightAnkle),
+    /// Bone connections we draw, with their preferred reference axis for
+    /// weight-stacking scoring. Face is omitted — eyes/ears rarely have
+    /// high enough confidence on dance footage and the noise would dominate
+    /// the colouring.
+    private static let skeleton: [SkeletonBone] = [
+        // shoulders & hips — level when stacked
+        SkeletonBone(start: .leftShoulder, end: .rightShoulder, axis: .horizontal),
+        SkeletonBone(start: .leftHip, end: .rightHip, axis: .horizontal),
+        // torso sides — vertical when stacked
+        SkeletonBone(start: .leftShoulder, end: .leftHip, axis: .vertical),
+        SkeletonBone(start: .rightShoulder, end: .rightHip, axis: .vertical),
+        // arms — neutral
+        SkeletonBone(start: .leftShoulder, end: .leftElbow, axis: .neutral),
+        SkeletonBone(start: .leftElbow, end: .leftWrist, axis: .neutral),
+        SkeletonBone(start: .rightShoulder, end: .rightElbow, axis: .neutral),
+        SkeletonBone(start: .rightElbow, end: .rightWrist, axis: .neutral),
+        // legs — vertical when stacked
+        SkeletonBone(start: .leftHip, end: .leftKnee, axis: .vertical),
+        SkeletonBone(start: .leftKnee, end: .leftAnkle, axis: .vertical),
+        SkeletonBone(start: .rightHip, end: .rightKnee, axis: .vertical),
+        SkeletonBone(start: .rightKnee, end: .rightAnkle, axis: .vertical),
     ]
+}
+
+extension Color {
+    /// Maps a `WeightStackingEvaluator` score to a stacking-themed colour:
+    /// red at 0, yellow at 0.5, green at 1. Endpoint values are tuned to
+    /// read well on top of black-letterboxed video — pure RGB primaries
+    /// look harsh, so we soften red and green slightly.
+    static func stackingColor(for score: Double) -> Color {
+        let s = max(0, min(1, score))
+        if s >= 0.5 {
+            // Yellow → green
+            let t = (s - 0.5) * 2
+            return Color(
+                red: 1.0 - 0.8 * t,
+                green: 0.85,
+                blue: 0.2 * t
+            )
+        } else {
+            // Red → yellow
+            let t = s * 2
+            return Color(
+                red: 1.0,
+                green: 0.2 + 0.65 * t,
+                blue: 0.0
+            )
+        }
+    }
 }
 
 /// Small chip rendered above the video when pose detection is enabled, so

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -207,7 +207,8 @@ struct PracticeView: View {
                             // the original frame's body.
                             PoseOverlay(
                                 pose: poseCoordinator.pose,
-                                imageSize: poseCoordinator.imageSize
+                                imageSize: poseCoordinator.imageSize,
+                                poseAge: poseCoordinator.poseAge
                             )
                             .scaleEffect(x: vm.mirrored ? -1 : 1, y: 1)
                         }

--- a/StepBackTests/WeightStackingEvaluatorTests.swift
+++ b/StepBackTests/WeightStackingEvaluatorTests.swift
@@ -1,0 +1,119 @@
+@testable import StepBack
+import CoreGraphics
+import XCTest
+
+final class WeightStackingEvaluatorTests: XCTestCase {
+
+    private let accuracy: Double = 0.001
+
+    // MARK: - Vertical axis
+
+    func testVerticalBoneScoresOneWhenPerfectlyVertical() {
+        // Straight down. View coords: positive y is down.
+        let score = WeightStackingEvaluator.alignmentScore(
+            from: CGPoint(x: 100, y: 100),
+            to: CGPoint(x: 100, y: 300),
+            axis: .vertical
+        )
+        XCTAssertEqual(score, 1.0, accuracy: accuracy)
+    }
+
+    func testVerticalBoneScoresOneWhenPerfectlyUpward() {
+        // Bone direction sign shouldn't matter — abs of dy.
+        let score = WeightStackingEvaluator.alignmentScore(
+            from: CGPoint(x: 100, y: 300),
+            to: CGPoint(x: 100, y: 100),
+            axis: .vertical
+        )
+        XCTAssertEqual(score, 1.0, accuracy: accuracy)
+    }
+
+    func testVerticalBoneScoresZeroAtForty5Degrees() {
+        // dx = dy = 100, angle from vertical = 45°.
+        let score = WeightStackingEvaluator.alignmentScore(
+            from: CGPoint(x: 0, y: 0),
+            to: CGPoint(x: 100, y: 100),
+            axis: .vertical
+        )
+        XCTAssertEqual(score, 0.0, accuracy: accuracy)
+    }
+
+    func testVerticalBoneScoresZeroBeyondForty5Degrees() {
+        // 30°/60° triangle — well past the 45° threshold (angle from
+        // vertical = 60°), so score is clamped to 0.
+        let score = WeightStackingEvaluator.alignmentScore(
+            from: CGPoint(x: 0, y: 0),
+            to: CGPoint(x: 100, y: 57.735),  // tan(30°) = 0.577…
+            axis: .vertical
+        )
+        XCTAssertEqual(score, 0.0, accuracy: accuracy)
+    }
+
+    func testVerticalBoneScoresHalfAtTwentyTwoPointFiveDegrees() {
+        // 22.5° off vertical → score = 1 - 22.5/45 = 0.5
+        let angle = 22.5 * .pi / 180
+        let dx = sin(angle) * 100
+        let dy = cos(angle) * 100
+        let score = WeightStackingEvaluator.alignmentScore(
+            from: CGPoint(x: 0, y: 0),
+            to: CGPoint(x: dx, y: dy),
+            axis: .vertical
+        )
+        XCTAssertEqual(score, 0.5, accuracy: accuracy)
+    }
+
+    // MARK: - Horizontal axis
+
+    func testHorizontalBoneScoresOneWhenPerfectlyHorizontal() {
+        let score = WeightStackingEvaluator.alignmentScore(
+            from: CGPoint(x: 0, y: 100),
+            to: CGPoint(x: 200, y: 100),
+            axis: .horizontal
+        )
+        XCTAssertEqual(score, 1.0, accuracy: accuracy)
+    }
+
+    func testHorizontalBoneScoresZeroAtForty5Degrees() {
+        let score = WeightStackingEvaluator.alignmentScore(
+            from: CGPoint(x: 0, y: 0),
+            to: CGPoint(x: 100, y: 100),
+            axis: .horizontal
+        )
+        XCTAssertEqual(score, 0.0, accuracy: accuracy)
+    }
+
+    func testHorizontalBoneScoresZeroWhenVertical() {
+        let score = WeightStackingEvaluator.alignmentScore(
+            from: CGPoint(x: 100, y: 0),
+            to: CGPoint(x: 100, y: 200),
+            axis: .horizontal
+        )
+        XCTAssertEqual(score, 0.0, accuracy: accuracy)
+    }
+
+    // MARK: - Neutral axis
+
+    func testNeutralBoneAlwaysScoresOne() {
+        // Same diagonal that scored 0 for vertical and horizontal.
+        let score = WeightStackingEvaluator.alignmentScore(
+            from: CGPoint(x: 0, y: 0),
+            to: CGPoint(x: 100, y: 100),
+            axis: .neutral
+        )
+        XCTAssertEqual(score, 1.0, accuracy: accuracy)
+    }
+
+    // MARK: - Degenerate input
+
+    func testZeroLengthBoneReturnsOne() {
+        // Same point for start and end — no meaningful direction to score.
+        // Prefer "fine" over NaN or 0 so the overlay doesn't flash red on
+        // a transient bad detection.
+        let score = WeightStackingEvaluator.alignmentScore(
+            from: CGPoint(x: 100, y: 100),
+            to: CGPoint(x: 100, y: 100),
+            axis: .vertical
+        )
+        XCTAssertEqual(score, 1.0, accuracy: accuracy)
+    }
+}


### PR DESCRIPTION
Two threads in one PR — both started from "pose detection breaks off + can we colour the lines for proper weight stacking."

## 1. Why detection was flickering

Three causes, all addressed:

- **Single-frame drops cleared the skeleton.** On dance footage Vision routinely returns nothing for one frame in five (motion blur, partial occlusion, dancer turning away). We were clearing `pose` on every miss.
  - Now: keep the last successful pose visible for up to 500ms. `PoseStreamCoordinator` publishes `poseAge: TimeInterval` and the overlay fades from solid → transparent over the back half of that window. *Solid* means "right now"; *fading* means "held from a moment ago." That's the answer to "is it actually detecting or just stuck?"
- **Paused-and-scrubbed frames weren't re-detected.** `tick()` bailed on `!hasNewPixelBuffer` even when the player time had jumped, so seeking around while paused never triggered a fresh detection.
  - Now: also re-run when `CMTime` advanced since the last process, not just on new-buffer events.
- **Confidence floor was eating real joints.** 0.3 is Apple's documented "reasonably reliable" floor, but dance footage routinely hits the 0.27-0.29 band on wrists/ankles during transitions.
  - Now: 0.25. Below 0.2 hands drift; that's the real floor.

## 2. Weight-stacking colour coding

For each bone we score how close it is to its preferred reference axis when the body is stacked:

| Bone | Reference axis |
|---|---|
| Torso sides (`shoulder→hip`) | vertical |
| Femur (`hip→knee`), Tibia (`knee→ankle`) | vertical |
| Shoulder line, Hip line | horizontal |
| Arms | neutral (full credit) |

`WeightStackingEvaluator.alignmentScore(from:to:axis:)` is pure: 0° off → 1.0, 22.5° → 0.5, 45° → 0. Hex tested directly — 10 cases covering vertical / horizontal / neutral axes, both bone directions, the threshold boundaries, and degenerate zero-length input.

`PoseOverlay` colours each bone via a red→yellow→green gradient keyed on its score, softened slightly from primary RGB so it reads well on top of letterboxed black. Joints stay white-tinted to register as anatomical landmarks regardless of surrounding hue. Confidence still drives stroke alpha — wobbly detections visibly weaken.

## What I didn't do (and why)

- **Identifying the "posted" (weight-bearing) leg.** That needs temporal tracking across multiple frames — which foot has been stationary, how long, where the centre of mass is over time. Clean v2 once we have a frame buffer. Without it, the per-bone scoring fluctuates during dynamic moves and paints green when actually stacked — which is the right signal for self-correction.
- **Overall stacking score chip.** Each bone tells its own story; adding a single number would either summarise meaningfully (needs the posted-leg detection above) or be misleading.

## Tests

**112/112 pass (was 102).** 10 new `WeightStackingEvaluatorTests`:
- Vertical / horizontal / neutral axis cases
- Both bone directions (sign-invariance via `abs`)
- Threshold boundaries (22.5° → 0.5, 45° → 0)
- Degenerate zero-length input (returns 1.0 — graceful fallback over NaN)
