### PR TITLE
Pose detection tuning: orientation, multi-observation, tick rate

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		B3A98425CA93181D0723AB60 /* AutoTagServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C54B956DF5DE01C00D95680 /* AutoTagServiceTests.swift */; };
 		B6CB4CFDF1EB16757B0D78AA /* CompareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D24FDCCE45AEFB352C5EBF /* CompareView.swift */; };
 		BE33E08127A1601493FB7837 /* LoopEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57317F752B65258CB2D04530 /* LoopEvaluatorTests.swift */; };
+		BF68180962319C57EBD42BA8 /* PoseOrientation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB61ACAF01042F0783B3CBD2 /* PoseOrientation.swift */; };
 		C376AB20647940A9E53A89D0 /* ModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848D52E156E709AA0226CEE8 /* ModelsTests.swift */; };
 		C7DD824378246BBC211824D8 /* ZoomablePlayerContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC399CE513ADED3ED5394848 /* ZoomablePlayerContainer.swift */; };
 		C97E59DA25A51E16ECA03607 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C112AEA59633E85CF8267D /* ThemeTests.swift */; };
@@ -47,6 +48,7 @@
 		D59006BDF41C10B002F97FE8 /* PoseOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08505D0FA11E6637197AF8EC /* PoseOverlay.swift */; };
 		D8739042EECB4AE2C7804C41 /* OriginalImportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D1395E84111ADD80CC22565 /* OriginalImportService.swift */; };
 		D9873262DD68100D8D3C1021 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 462E264B215595E9EC3D1C4A /* Assets.xcassets */; };
+		D9AC9EB80E5FBEC30A1AB5B3 /* PoseOrientationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 284F5B49794793B83D590351 /* PoseOrientationTests.swift */; };
 		DA0EE94353A18DA75824D7A8 /* BeatGridTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7093A077C0A2C139BD7BDD29 /* BeatGridTests.swift */; };
 		E709F2C42DEFD624E08A9C35 /* TrimExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCED6C8E1CE7A48B341C8B1 /* TrimExportService.swift */; };
 		E9E06DF791FF47015B3DDFA8 /* BeatDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59BD8F65AE46261EEFD4F69 /* BeatDetector.swift */; };
@@ -72,6 +74,7 @@
 		08505D0FA11E6637197AF8EC /* PoseOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoseOverlay.swift; sourceTree = "<group>"; };
 		0C54B956DF5DE01C00D95680 /* AutoTagServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoTagServiceTests.swift; sourceTree = "<group>"; };
 		16E676751B59ED083837CE39 /* SpeedFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedFormatterTests.swift; sourceTree = "<group>"; };
+		284F5B49794793B83D590351 /* PoseOrientationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoseOrientationTests.swift; sourceTree = "<group>"; };
 		2D07843122196F5F0DA539D1 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		35AE6C8D6564306E1B0ADA20 /* PracticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeView.swift; sourceTree = "<group>"; };
 		46242480BEBB0CDD9B45F158 /* NowPlayingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingController.swift; sourceTree = "<group>"; };
@@ -101,6 +104,7 @@
 		A3776C829FB11907CC7E87F9 /* StepBack.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = StepBack.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5844567C104B87D338953E6 /* PoseStreamCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoseStreamCoordinator.swift; sourceTree = "<group>"; };
 		AAB30650146433E889DC2AF4 /* LibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryView.swift; sourceTree = "<group>"; };
+		AB61ACAF01042F0783B3CBD2 /* PoseOrientation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoseOrientation.swift; sourceTree = "<group>"; };
 		AC399CE513ADED3ED5394848 /* ZoomablePlayerContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomablePlayerContainer.swift; sourceTree = "<group>"; };
 		B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosServiceTests.swift; sourceTree = "<group>"; };
 		B7C112AEA59633E85CF8267D /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
@@ -165,6 +169,7 @@
 				EF4094CC2957462A284F735A /* OriginalImportServiceTests.swift */,
 				B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */,
 				ED02929698766149F5A683B1 /* PoseCoordinateTransformTests.swift */,
+				284F5B49794793B83D590351 /* PoseOrientationTests.swift */,
 				16E676751B59ED083837CE39 /* SpeedFormatterTests.swift */,
 				808127290713ACE9855DA35E /* StepBackMigrationPlanTests.swift */,
 				DB3B8C1BB7ACE2D1C13C7200 /* StepTimingTests.swift */,
@@ -186,6 +191,7 @@
 				D8F8476EAB523378C1F1E046 /* PhotosService.swift */,
 				75D7B3643B17B81DF4B8A3D8 /* PoseCoordinateTransform.swift */,
 				5D718DA7FBF3C3F0248929A7 /* PoseDetectionService.swift */,
+				AB61ACAF01042F0783B3CBD2 /* PoseOrientation.swift */,
 				A5844567C104B87D338953E6 /* PoseStreamCoordinator.swift */,
 				543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */,
 				94AAA488969D7CF77497859D /* SegmentThumbnailGenerator.swift */,
@@ -338,6 +344,7 @@
 				F7AD3FACE8B875F1C9DFA310 /* PhotosService.swift in Sources */,
 				782B609F039BD291571F9CB2 /* PoseCoordinateTransform.swift in Sources */,
 				6BEA9ED6D92F4B26B85BFA21 /* PoseDetectionService.swift in Sources */,
+				BF68180962319C57EBD42BA8 /* PoseOrientation.swift in Sources */,
 				D59006BDF41C10B002F97FE8 /* PoseOverlay.swift in Sources */,
 				52562CC7EBC717613965ADAB /* PoseStreamCoordinator.swift in Sources */,
 				03C973FD27336E9DD2EDE507 /* PracticeBeatUI.swift in Sources */,
@@ -371,6 +378,7 @@
 				648013A1A4C23692CD6ED03B /* OriginalImportServiceTests.swift in Sources */,
 				CC6F98E7716925F88449689A /* PhotosServiceTests.swift in Sources */,
 				FF149265E884C202BEF590BE /* PoseCoordinateTransformTests.swift in Sources */,
+				D9AC9EB80E5FBEC30A1AB5B3 /* PoseOrientationTests.swift in Sources */,
 				F35848C14CA3DF06A4EBE554 /* SpeedFormatterTests.swift in Sources */,
 				9799CACB6C924AC1940D9FE3 /* StepBackMigrationPlanTests.swift in Sources */,
 				4181110140BD581DBFB0A380 /* StepTimingTests.swift in Sources */,

--- a/StepBack/Services/PoseDetectionService.swift
+++ b/StepBack/Services/PoseDetectionService.swift
@@ -50,6 +50,10 @@ struct PoseDetectionService: Sendable {
         orientation: CGImagePropertyOrientation = .up
     ) throws -> DetectedPose? {
         let request = VNDetectHumanBodyPoseRequest()
+        // Pin to the newest revision the OS supports rather than letting
+        // the default float — same model behaviour from device to device,
+        // and we get whatever accuracy improvements ship with each iOS.
+        request.revision = VNDetectHumanBodyPoseRequest.currentRevision
         let handler = VNImageRequestHandler(
             cvPixelBuffer: pixelBuffer,
             orientation: orientation,
@@ -60,7 +64,14 @@ struct PoseDetectionService: Sendable {
         } catch {
             throw PoseDetectionError.visionFailed(error.localizedDescription)
         }
-        guard let observation = (request.results ?? []).first else { return nil }
+        // Pick the highest overall-confidence observation, not just the
+        // first. With multiple people in frame (common at social dances)
+        // the model returns them in essentially arbitrary order, which
+        // made the skeleton jump between dancers. Highest confidence is
+        // a stable proxy for "the most clearly-visible person."
+        let observations = request.results ?? []
+        guard let observation = observations.max(by: { $0.confidence < $1.confidence })
+        else { return nil }
         let allPoints: [VNHumanBodyPoseObservation.JointName: VNRecognizedPoint]
         do {
             allPoints = try observation.recognizedPoints(.all)

--- a/StepBack/Services/PoseOrientation.swift
+++ b/StepBack/Services/PoseOrientation.swift
@@ -1,0 +1,47 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+
+extension CGImagePropertyOrientation {
+
+    /// Decodes the rotation embedded in an `AVAssetTrack.preferredTransform`
+    /// into a `CGImagePropertyOrientation` we can hand to Vision.
+    ///
+    /// iPhone-shot portrait videos are stored landscape with a 90° CW
+    /// transform — without this decode we'd tell Vision the image is
+    /// `.up`, and Vision would try to detect a sideways body and quietly
+    /// miss. Falls back to `.up` for anything we don't recognise (skewed
+    /// transforms, near-identity edge cases) so behaviour matches the
+    /// pre-orientation code on weird sources.
+    ///
+    /// We deliberately don't handle the mirror variants for now —
+    /// `AVPlayerItemVideoOutput` doesn't pre-mirror selfie-camera buffers
+    /// for us, but the visual flip is small enough that Vision still
+    /// detects fine. Revisit if a real front-camera clip drifts.
+    init(transform: CGAffineTransform) {
+        let angle = atan2(transform.b, transform.a)
+        let tolerance = 0.1
+        if abs(angle) < tolerance {
+            self = .up
+        } else if abs(angle - .pi / 2) < tolerance {
+            self = .right
+        } else if abs(angle - .pi) < tolerance || abs(angle + .pi) < tolerance {
+            self = .down
+        } else if abs(angle + .pi / 2) < tolerance {
+            self = .left
+        } else {
+            self = .up
+        }
+    }
+
+    /// True when this orientation rotates the source by 90° — i.e. the
+    /// upright image's width and height are swapped from the storage
+    /// buffer's. Drives the `imageSize` axis swap in the coordinator so the
+    /// overlay maps joint coords to the *displayed* aspect, not storage.
+    var swapsAxes: Bool {
+        switch self {
+        case .left, .right, .leftMirrored, .rightMirrored: true
+        default: false
+        }
+    }
+}

--- a/StepBack/Services/PoseStreamCoordinator.swift
+++ b/StepBack/Services/PoseStreamCoordinator.swift
@@ -2,6 +2,7 @@ import AVFoundation
 import Combine
 import CoreVideo
 import Foundation
+import ImageIO
 
 /// Drives pose detection against an `AVPlayer`'s currently-displayed frame.
 /// Attaches an `AVPlayerItemVideoOutput` to whatever item is current, polls
@@ -32,10 +33,12 @@ final class PoseStreamCoordinator: ObservableObject {
     /// stale frame vs reading the current one.
     @Published private(set) var poseAge: TimeInterval = .infinity
 
-    /// 100ms tick. At 10Hz, Vision's body-pose request runs cheaply enough
-    /// to stay out of the main thread budget (work happens on
-    /// `detectionQueue`) while still feeling reactive on the overlay.
-    private static let tickInterval: Duration = .milliseconds(100)
+    /// 60ms tick (~16Hz). Was 100ms — bumped up because Vision routinely
+    /// misses individual frames on dance footage and more attempts per
+    /// second materially improves coverage. Detection runs on a background
+    /// queue so the main thread isn't squeezed; the actual cycle time is
+    /// roughly tickInterval + detection_time (~10-30ms on iPhone 12+).
+    private static let tickInterval: Duration = .milliseconds(60)
     /// Last successful pose stays visible for this long after detection
     /// starts failing. Bridges the flicker when Vision drops a frame or
     /// two on hard footage (motion blur, partial occlusion, etc).
@@ -51,6 +54,13 @@ final class PoseStreamCoordinator: ObservableObject {
     private var tickTask: Task<Void, Never>?
     private var lastSuccessTime: Date?
     private var lastProcessedTime: CMTime?
+    /// Cached `CGImagePropertyOrientation` derived from the current player
+    /// item's video track preferredTransform. Set asynchronously after the
+    /// item swaps; until resolved we default to `.up`, which matches the
+    /// pre-orientation behaviour.
+    private var orientation: CGImagePropertyOrientation = .up
+    private weak var orientationItem: AVPlayerItem?
+    private var orientationTask: Task<Void, Never>?
 
     init(
         player: AVPlayer,
@@ -115,8 +125,47 @@ final class PoseStreamCoordinator: ObservableObject {
         }
     }
 
+    /// Resolves the current item's video orientation from its preferred
+    /// transform. Cached by item identity so we don't re-load the track
+    /// on every tick — and so swapping items (after trim, after reload)
+    /// triggers a fresh resolution. Until the async load completes we
+    /// stay at the cached value, which on first item is `.up`.
+    private func updateOrientationIfNeeded() {
+        guard let item = player.currentItem else { return }
+        if item === orientationItem { return }
+        orientationItem = item
+        // Reset cached imageSize so it gets re-derived with the new
+        // orientation on the next pixel-buffer copy.
+        imageSize = nil
+        orientationTask?.cancel()
+        orientationTask = Task { [weak self] in
+            let resolved = await Self.resolveOrientation(for: item)
+            await MainActor.run {
+                guard let self else { return }
+                guard self.orientationItem === item else { return }
+                self.orientation = resolved
+            }
+        }
+    }
+
+    /// Async-loads the video track's preferred transform off the main
+    /// actor so the tick doesn't block on it.
+    nonisolated private static func resolveOrientation(
+        for item: AVPlayerItem
+    ) async -> CGImagePropertyOrientation {
+        do {
+            let tracks = try await item.asset.loadTracks(withMediaType: .video)
+            guard let track = tracks.first else { return .up }
+            let transform = try await track.load(.preferredTransform)
+            return CGImagePropertyOrientation(transform: transform)
+        } catch {
+            return .up
+        }
+    }
+
     private func tick() async {
         attachOutputIfNeeded()
+        updateOrientationIfNeeded()
         guard player.currentItem != nil else { return }
         let time = player.currentTime()
 
@@ -145,13 +194,20 @@ final class PoseStreamCoordinator: ObservableObject {
         lastProcessedTime = time
 
         if imageSize == nil {
-            imageSize = CGSize(
+            let raw = CGSize(
                 width: CVPixelBufferGetWidth(pixelBuffer),
                 height: CVPixelBufferGetHeight(pixelBuffer)
             )
+            // Vision returns joint coords in the upright (orientation-
+            // corrected) frame, so we need to surface the *displayed*
+            // dimensions for the overlay's aspect-fit math — that means
+            // swapping width and height for 90°-rotated sources.
+            imageSize = orientation.swapsAxes
+                ? CGSize(width: raw.height, height: raw.width)
+                : raw
         }
 
-        let result = await detect(pixelBuffer: pixelBuffer)
+        let result = await detect(pixelBuffer: pixelBuffer, orientation: orientation)
         switch result {
         case .success(let detected):
             if let detected {
@@ -207,12 +263,15 @@ final class PoseStreamCoordinator: ObservableObject {
     /// Runs the synchronous Vision request on `detectionQueue` and bridges
     /// back to MainActor via a continuation. We capture `detector` by value
     /// so the queue closure doesn't touch `self` across the actor boundary.
-    private func detect(pixelBuffer: CVPixelBuffer) async -> Result<DetectedPose?, Error> {
+    private func detect(
+        pixelBuffer: CVPixelBuffer,
+        orientation: CGImagePropertyOrientation
+    ) async -> Result<DetectedPose?, Error> {
         let detector = self.detector
         return await withCheckedContinuation { continuation in
             detectionQueue.async {
                 let outcome = Result {
-                    try detector.detect(in: pixelBuffer)
+                    try detector.detect(in: pixelBuffer, orientation: orientation)
                 }
                 continuation.resume(returning: outcome)
             }

--- a/StepBackTests/PoseOrientationTests.swift
+++ b/StepBackTests/PoseOrientationTests.swift
@@ -1,0 +1,79 @@
+@testable import StepBack
+import CoreGraphics
+import ImageIO
+import XCTest
+
+final class PoseOrientationTests: XCTestCase {
+
+    // MARK: - Init from CGAffineTransform
+
+    func testIdentityTransformIsUp() {
+        XCTAssertEqual(
+            CGImagePropertyOrientation(transform: .identity),
+            .up
+        )
+    }
+
+    func testRotate90ClockwiseIsRight() {
+        // iPhone-shot portrait videos land here. Storage buffer is
+        // landscape, displayed portrait by rotating 90° CW.
+        let t = CGAffineTransform(rotationAngle: .pi / 2)
+        XCTAssertEqual(
+            CGImagePropertyOrientation(transform: t),
+            .right
+        )
+    }
+
+    func testRotate180IsDown() {
+        let t = CGAffineTransform(rotationAngle: .pi)
+        XCTAssertEqual(
+            CGImagePropertyOrientation(transform: t),
+            .down
+        )
+    }
+
+    func testRotateNegative180IsDown() {
+        // atan2 returns -π for a 180° rotation when entered as -π.
+        // Both should map to .down.
+        let t = CGAffineTransform(rotationAngle: -.pi)
+        XCTAssertEqual(
+            CGImagePropertyOrientation(transform: t),
+            .down
+        )
+    }
+
+    func testRotate90CounterclockwiseIsLeft() {
+        let t = CGAffineTransform(rotationAngle: -.pi / 2)
+        XCTAssertEqual(
+            CGImagePropertyOrientation(transform: t),
+            .left
+        )
+    }
+
+    func testWeirdTransformFallsBackToUp() {
+        // A non-90° rotation isn't something we expect from AVAsset's
+        // preferredTransform, but if we ever get one the pipeline should
+        // degrade gracefully — Vision still mostly works on .up sources.
+        let t = CGAffineTransform(rotationAngle: .pi / 3)  // 60°
+        XCTAssertEqual(
+            CGImagePropertyOrientation(transform: t),
+            .up
+        )
+    }
+
+    // MARK: - Axis swap
+
+    func testSwapsAxesIsTrueForLeftAndRight() {
+        XCTAssertTrue(CGImagePropertyOrientation.left.swapsAxes)
+        XCTAssertTrue(CGImagePropertyOrientation.right.swapsAxes)
+        XCTAssertTrue(CGImagePropertyOrientation.leftMirrored.swapsAxes)
+        XCTAssertTrue(CGImagePropertyOrientation.rightMirrored.swapsAxes)
+    }
+
+    func testSwapsAxesIsFalseForUpAndDown() {
+        XCTAssertFalse(CGImagePropertyOrientation.up.swapsAxes)
+        XCTAssertFalse(CGImagePropertyOrientation.down.swapsAxes)
+        XCTAssertFalse(CGImagePropertyOrientation.upMirrored.swapsAxes)
+        XCTAssertFalse(CGImagePropertyOrientation.downMirrored.swapsAxes)
+    }
+}


### PR DESCRIPTION
Pose detection tuning. The biggest single fix is orientation handling — I'm 90% confident this was responsible for most of your "doesn't detect every time" reports on portrait clips.

## The orientation problem

When you shoot a portrait video on iPhone, the file is *actually* stored landscape (e.g. 1920×1080), with a 90° CW `preferredTransform` that the player applies on display. `AVPlayerItemVideoOutput` hands us the **storage** buffer, *not* the displayed one. We were telling Vision `orientation: .up` regardless — so Vision was trying to detect a sideways body and quietly missing.

### Fix

- `CGImagePropertyOrientation(transform:)` decodes the asset's preferred transform → the right Vision orientation hint:
  - identity → `.up`
  - 90° CW → `.right`
  - 180° → `.down`
  - 270° CW → `.left`
- `swapsAxes` tells the coordinator when to swap `width`/`height` for `imageSize` (Vision returns coords in the upright frame, so the displayed size is what the overlay's aspect-fit math needs).
- `PoseStreamCoordinator` caches orientation per `AVPlayerItem` identity and reloads asynchronously after item swaps (trim export, reload).

## Other knobs turned

### Multi-observation selection

`VNDetectHumanBodyPoseRequest` returns *all* people in frame. We were taking `.first`, which is essentially arbitrary order — at a social dance with multiple people the skeleton was jumping between dancers. Now: highest-overall-confidence observation, which is a stable proxy for "the most clearly-visible person."

### Tick rate: 100ms → 60ms

~16Hz instead of 10Hz. Detection runs on a background queue so this doesn't squeeze the main thread; the actual cycle is `tickInterval + ~10–30ms` detection time. More attempts per second = more chances to catch the dancer between hard frames.

### Pinned request revision

`request.revision = VNDetectHumanBodyPoseRequest.currentRevision`. Same model behaviour device-to-device, and we pick up new revisions as iOS ships them rather than the historical default floating.

## Knobs explicitly *not* turned this round

- **Brightness/contrast preprocessing** for dim stage lighting — adds complexity, easy to introduce false positives in already-bright scenes
- **Temporal Kalman smoothing** on joint positions — helps perceived stability but not actual misses
- **Region-of-interest cropping** for small/distant dancers — needs a separate `VNDetectHumanRectangles` pass first
- **3D pose** (`VNDetectHumanBodyPose3DRequest`) — iOS 17+, heavier; revisit only if 2D doesn't carry

## Tests

**120/120 pass (was 112).** 8 new `PoseOrientationTests`:

- Identity transform → `.up`
- 90° CW → `.right`
- 180° (both `+π` and `-π` forms) → `.down`
- 270° CW → `.left`
- Non-cardinal angle → graceful `.up` fallback
- `swapsAxes` for all eight orientations
