### PR TITLE
Temporal smoothing for the pose skeleton (#75)

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -12,12 +12,14 @@
 		1D0BE1897582A939153E6CE8 /* ClipEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D25E6771271EDD5B867F61E /* ClipEditView.swift */; };
 		1EC09265A1CD5B1E67415B39 /* StepBackApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023608F63978F9D1668F5AFC /* StepBackApp.swift */; };
 		1F02ADF6471B01E48A824A49 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6745FF48B10D28A5ED4BB568 /* Models.swift */; };
+		2A336DDDB2437ABD5AA689CC /* OneEuroFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CFE766261001C15EFAA5C2 /* OneEuroFilterTests.swift */; };
 		2B90619AE0B5262B774DEAC1 /* PracticeControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35987D9825155E131A40950 /* PracticeControls.swift */; };
 		3D990657ED52C04DBB04687A /* NowPlayingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46242480BEBB0CDD9B45F158 /* NowPlayingController.swift */; };
 		4181110140BD581DBFB0A380 /* StepTimingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3B8C1BB7ACE2D1C13C7200 /* StepTimingTests.swift */; };
 		52562CC7EBC717613965ADAB /* PoseStreamCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5844567C104B87D338953E6 /* PoseStreamCoordinator.swift */; };
 		527B9B596B00D2C774173ECA /* PracticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35AE6C8D6564306E1B0ADA20 /* PracticeView.swift */; };
 		5F405BD1B2F2EB7F30970683 /* LibraryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */; };
+		61CF9C7EABDA7AF4C9FE3991 /* PoseSmoother.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B555006BB3DDAF7885AA331 /* PoseSmoother.swift */; };
 		622A6663058E88A57B465B62 /* StepTiming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0265ABC8E91AF4657EB95F83 /* StepTiming.swift */; };
 		648013A1A4C23692CD6ED03B /* OriginalImportServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF4094CC2957462A284F735A /* OriginalImportServiceTests.swift */; };
 		691A3AE86C110C252A1412FE /* BeatGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078CB839E392E788201DD665 /* BeatGrid.swift */; };
@@ -38,6 +40,7 @@
 		AD47C4CE36AF1FD4FF011BCC /* SegmentThumbnailGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94AAA488969D7CF77497859D /* SegmentThumbnailGenerator.swift */; };
 		B3A98425CA93181D0723AB60 /* AutoTagServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C54B956DF5DE01C00D95680 /* AutoTagServiceTests.swift */; };
 		B6CB4CFDF1EB16757B0D78AA /* CompareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D24FDCCE45AEFB352C5EBF /* CompareView.swift */; };
+		BAD8216387EC26539DBB6E8C /* PoseSmootherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AAC69A2C2F4F581525FFA41 /* PoseSmootherTests.swift */; };
 		BE33E08127A1601493FB7837 /* LoopEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57317F752B65258CB2D04530 /* LoopEvaluatorTests.swift */; };
 		BF68180962319C57EBD42BA8 /* PoseOrientation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB61ACAF01042F0783B3CBD2 /* PoseOrientation.swift */; };
 		C376AB20647940A9E53A89D0 /* ModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848D52E156E709AA0226CEE8 /* ModelsTests.swift */; };
@@ -52,6 +55,7 @@
 		DA0EE94353A18DA75824D7A8 /* BeatGridTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7093A077C0A2C139BD7BDD29 /* BeatGridTests.swift */; };
 		E709F2C42DEFD624E08A9C35 /* TrimExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCED6C8E1CE7A48B341C8B1 /* TrimExportService.swift */; };
 		E9E06DF791FF47015B3DDFA8 /* BeatDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59BD8F65AE46261EEFD4F69 /* BeatDetector.swift */; };
+		ED3E826645A88F1EA36A182D /* OneEuroFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FE50463A4FCC200646F955 /* OneEuroFilter.swift */; };
 		F35848C14CA3DF06A4EBE554 /* SpeedFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E676751B59ED083837CE39 /* SpeedFormatterTests.swift */; };
 		F7AD3FACE8B875F1C9DFA310 /* PhotosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F8476EAB523378C1F1E046 /* PhotosService.swift */; };
 		FF149265E884C202BEF590BE /* PoseCoordinateTransformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED02929698766149F5A683B1 /* PoseCoordinateTransformTests.swift */; };
@@ -81,6 +85,7 @@
 		462E264B215595E9EC3D1C4A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		46ED8A21F9D36A90E3306D55 /* StepBackTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = StepBackTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4D1395E84111ADD80CC22565 /* OriginalImportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OriginalImportService.swift; sourceTree = "<group>"; };
+		51CFE766261001C15EFAA5C2 /* OneEuroFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneEuroFilterTests.swift; sourceTree = "<group>"; };
 		543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticePlayerViewModel.swift; sourceTree = "<group>"; };
 		5445312DC1A378A65F963DD7 /* Schema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Schema.swift; sourceTree = "<group>"; };
 		562F2A8FB404F08A50DABD0B /* WeightStackingEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightStackingEvaluatorTests.swift; sourceTree = "<group>"; };
@@ -92,8 +97,11 @@
 		7093A077C0A2C139BD7BDD29 /* BeatGridTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeatGridTests.swift; sourceTree = "<group>"; };
 		71643D36F7F8D028B560F012 /* TrimAnnotationShifter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimAnnotationShifter.swift; sourceTree = "<group>"; };
 		75D7B3643B17B81DF4B8A3D8 /* PoseCoordinateTransform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoseCoordinateTransform.swift; sourceTree = "<group>"; };
+		75FE50463A4FCC200646F955 /* OneEuroFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneEuroFilter.swift; sourceTree = "<group>"; };
+		7B555006BB3DDAF7885AA331 /* PoseSmoother.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoseSmoother.swift; sourceTree = "<group>"; };
 		808127290713ACE9855DA35E /* StepBackMigrationPlanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepBackMigrationPlanTests.swift; sourceTree = "<group>"; };
 		848D52E156E709AA0226CEE8 /* ModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsTests.swift; sourceTree = "<group>"; };
+		8AAC69A2C2F4F581525FFA41 /* PoseSmootherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoseSmootherTests.swift; sourceTree = "<group>"; };
 		8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryFormatterTests.swift; sourceTree = "<group>"; };
 		8D25E6771271EDD5B867F61E /* ClipEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipEditView.swift; sourceTree = "<group>"; };
 		90115F7F368CDD3B0832B3B3 /* Generated-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Generated-Info.plist"; sourceTree = "<group>"; };
@@ -166,10 +174,12 @@
 				8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */,
 				57317F752B65258CB2D04530 /* LoopEvaluatorTests.swift */,
 				848D52E156E709AA0226CEE8 /* ModelsTests.swift */,
+				51CFE766261001C15EFAA5C2 /* OneEuroFilterTests.swift */,
 				EF4094CC2957462A284F735A /* OriginalImportServiceTests.swift */,
 				B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */,
 				ED02929698766149F5A683B1 /* PoseCoordinateTransformTests.swift */,
 				284F5B49794793B83D590351 /* PoseOrientationTests.swift */,
+				8AAC69A2C2F4F581525FFA41 /* PoseSmootherTests.swift */,
 				16E676751B59ED083837CE39 /* SpeedFormatterTests.swift */,
 				808127290713ACE9855DA35E /* StepBackMigrationPlanTests.swift */,
 				DB3B8C1BB7ACE2D1C13C7200 /* StepTimingTests.swift */,
@@ -187,11 +197,13 @@
 				C59BD8F65AE46261EEFD4F69 /* BeatDetector.swift */,
 				078CB839E392E788201DD665 /* BeatGrid.swift */,
 				46242480BEBB0CDD9B45F158 /* NowPlayingController.swift */,
+				75FE50463A4FCC200646F955 /* OneEuroFilter.swift */,
 				4D1395E84111ADD80CC22565 /* OriginalImportService.swift */,
 				D8F8476EAB523378C1F1E046 /* PhotosService.swift */,
 				75D7B3643B17B81DF4B8A3D8 /* PoseCoordinateTransform.swift */,
 				5D718DA7FBF3C3F0248929A7 /* PoseDetectionService.swift */,
 				AB61ACAF01042F0783B3CBD2 /* PoseOrientation.swift */,
+				7B555006BB3DDAF7885AA331 /* PoseSmoother.swift */,
 				A5844567C104B87D338953E6 /* PoseStreamCoordinator.swift */,
 				543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */,
 				94AAA488969D7CF77497859D /* SegmentThumbnailGenerator.swift */,
@@ -340,12 +352,14 @@
 				A88000A1ACD9503F7A9D6143 /* LibraryView.swift in Sources */,
 				1F02ADF6471B01E48A824A49 /* Models.swift in Sources */,
 				3D990657ED52C04DBB04687A /* NowPlayingController.swift in Sources */,
+				ED3E826645A88F1EA36A182D /* OneEuroFilter.swift in Sources */,
 				D8739042EECB4AE2C7804C41 /* OriginalImportService.swift in Sources */,
 				F7AD3FACE8B875F1C9DFA310 /* PhotosService.swift in Sources */,
 				782B609F039BD291571F9CB2 /* PoseCoordinateTransform.swift in Sources */,
 				6BEA9ED6D92F4B26B85BFA21 /* PoseDetectionService.swift in Sources */,
 				BF68180962319C57EBD42BA8 /* PoseOrientation.swift in Sources */,
 				D59006BDF41C10B002F97FE8 /* PoseOverlay.swift in Sources */,
+				61CF9C7EABDA7AF4C9FE3991 /* PoseSmoother.swift in Sources */,
 				52562CC7EBC717613965ADAB /* PoseStreamCoordinator.swift in Sources */,
 				03C973FD27336E9DD2EDE507 /* PracticeBeatUI.swift in Sources */,
 				2B90619AE0B5262B774DEAC1 /* PracticeControls.swift in Sources */,
@@ -375,10 +389,12 @@
 				5F405BD1B2F2EB7F30970683 /* LibraryFormatterTests.swift in Sources */,
 				BE33E08127A1601493FB7837 /* LoopEvaluatorTests.swift in Sources */,
 				C376AB20647940A9E53A89D0 /* ModelsTests.swift in Sources */,
+				2A336DDDB2437ABD5AA689CC /* OneEuroFilterTests.swift in Sources */,
 				648013A1A4C23692CD6ED03B /* OriginalImportServiceTests.swift in Sources */,
 				CC6F98E7716925F88449689A /* PhotosServiceTests.swift in Sources */,
 				FF149265E884C202BEF590BE /* PoseCoordinateTransformTests.swift in Sources */,
 				D9AC9EB80E5FBEC30A1AB5B3 /* PoseOrientationTests.swift in Sources */,
+				BAD8216387EC26539DBB6E8C /* PoseSmootherTests.swift in Sources */,
 				F35848C14CA3DF06A4EBE554 /* SpeedFormatterTests.swift in Sources */,
 				9799CACB6C924AC1940D9FE3 /* StepBackMigrationPlanTests.swift in Sources */,
 				4181110140BD581DBFB0A380 /* StepTimingTests.swift in Sources */,

--- a/StepBack/Services/OneEuroFilter.swift
+++ b/StepBack/Services/OneEuroFilter.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Adaptive low-pass filter (Casiez, Roussel & Vogel, 2012) for smoothing a
+/// noisy 1-D signal sampled at irregular intervals.
+///
+/// The cutoff frequency rises with the signal's speed: it removes jitter
+/// when the value is roughly stationary but stays responsive during fast
+/// motion. That's exactly the trade-off a dancing skeleton needs — steady
+/// when the dancer is posed, snappy on a kick — and it's why a plain
+/// fixed-cutoff low-pass (which would lag every fast move) isn't enough.
+///
+/// Pure value type: deterministic for a given input sequence, so it's
+/// unit-tested directly without a player or Vision.
+struct OneEuroFilter {
+
+    /// Minimum cutoff frequency (Hz). Lower = smoother but laggier at rest.
+    let minCutoff: Double
+    /// Speed coefficient. Higher = more responsive during fast motion (less
+    /// lag) at the cost of letting more jitter through while moving.
+    let beta: Double
+    /// Cutoff for the derivative's own low-pass. 1.0 is the paper's default
+    /// and rarely needs tuning.
+    let dCutoff: Double
+
+    private var lastRawValue: Double?
+    private var filteredValue: Double?       // x̂_{t-1}
+    private var filteredDerivative: Double?  // dx̂_{t-1}
+    private var lastTimestamp: Double?
+
+    init(minCutoff: Double = 1.0, beta: Double = 0.0, dCutoff: Double = 1.0) {
+        self.minCutoff = minCutoff
+        self.beta = beta
+        self.dCutoff = dCutoff
+    }
+
+    /// Exponential smoothing factor for a cutoff frequency and timestep.
+    /// `dt` must be > 0; callers guarantee that.
+    private static func alpha(cutoff: Double, dt: Double) -> Double {
+        let tau = 1.0 / (2.0 * .pi * cutoff)
+        return 1.0 / (1.0 + tau / dt)
+    }
+
+    /// Feeds a new sample and returns the smoothed value. `timestamp` is in
+    /// seconds; intervals may be irregular. The first sample passes through
+    /// unchanged (nothing to smooth against yet). A non-monotonic timestamp
+    /// (a seek backward, or the same frame twice) is treated as a
+    /// discontinuity and also passes through, resetting the derivative.
+    mutating func filter(_ value: Double, timestamp: Double) -> Double {
+        defer {
+            lastRawValue = value
+            lastTimestamp = timestamp
+        }
+
+        guard let lastTimestamp, let previousFiltered = filteredValue else {
+            filteredValue = value
+            filteredDerivative = 0
+            return value
+        }
+
+        let dt = timestamp - lastTimestamp
+        guard dt > 0 else {
+            filteredValue = value
+            filteredDerivative = 0
+            return value
+        }
+
+        // Derivative of the raw signal, itself low-passed before it drives
+        // the adaptive cutoff.
+        let rawDerivative = (value - (lastRawValue ?? value)) / dt
+        let aDerivative = Self.alpha(cutoff: dCutoff, dt: dt)
+        let previousDerivative = filteredDerivative ?? 0
+        let smoothedDerivative =
+            aDerivative * rawDerivative + (1 - aDerivative) * previousDerivative
+        filteredDerivative = smoothedDerivative
+
+        // Cutoff rises with speed → less smoothing (more responsiveness)
+        // during fast motion.
+        let cutoff = minCutoff + beta * abs(smoothedDerivative)
+        let a = Self.alpha(cutoff: cutoff, dt: dt)
+        let smoothed = a * value + (1 - a) * previousFiltered
+        filteredValue = smoothed
+        return smoothed
+    }
+
+    /// Forgets all history. The next sample passes through as a fresh start.
+    mutating func reset() {
+        lastRawValue = nil
+        filteredValue = nil
+        filteredDerivative = nil
+        lastTimestamp = nil
+    }
+}

--- a/StepBack/Services/PoseSmoother.swift
+++ b/StepBack/Services/PoseSmoother.swift
@@ -1,0 +1,74 @@
+import CoreGraphics
+import Foundation
+import Vision
+
+/// Applies per-joint One-Euro smoothing to a stream of detected poses so the
+/// rendered skeleton stops shimmering between frames. Each joint gets an
+/// independent pair of x/y filters keyed by joint name; a joint that vanishes
+/// and reappears simply picks up a fresh filter on its return.
+///
+/// Filter parameters are tuned for Vision's **normalized** coordinates
+/// (0…1), where joint velocities are small (a hand crossing the frame in
+/// half a second is ~2 units/s). `beta` is higher than a pixel-space default
+/// would be so fast limbs don't lag.
+struct PoseSmoother {
+
+    let minCutoff: Double
+    let beta: Double
+    /// A timestep larger than this (seconds) is treated as a seek / scene
+    /// cut: all filters reset so the skeleton snaps to the new frame instead
+    /// of smearing a path between two unrelated poses.
+    let resetGap: Double
+
+    private struct JointFilter {
+        var x: OneEuroFilter
+        var y: OneEuroFilter
+    }
+
+    private var filters: [VNHumanBodyPoseObservation.JointName: JointFilter] = [:]
+    private var lastTimestamp: Double?
+
+    init(minCutoff: Double = 1.0, beta: Double = 0.5, resetGap: Double = 0.4) {
+        self.minCutoff = minCutoff
+        self.beta = beta
+        self.resetGap = resetGap
+    }
+
+    /// Returns a copy of `pose` with every joint position smoothed against
+    /// the running history. `timestamp` should be a monotonic media clock;
+    /// non-monotonic or large jumps reset the filters first.
+    mutating func smooth(_ pose: DetectedPose, timestamp: Double) -> DetectedPose {
+        if let last = lastTimestamp,
+           timestamp <= last || timestamp - last > resetGap {
+            filters.removeAll()
+        }
+        lastTimestamp = timestamp
+
+        let smoothedJoints = pose.joints.map { joint -> DetectedJoint in
+            var jointFilter = filters[joint.name] ?? JointFilter(
+                x: OneEuroFilter(minCutoff: minCutoff, beta: beta),
+                y: OneEuroFilter(minCutoff: minCutoff, beta: beta)
+            )
+            let sx = jointFilter.x.filter(
+                Double(joint.normalizedPosition.x), timestamp: timestamp
+            )
+            let sy = jointFilter.y.filter(
+                Double(joint.normalizedPosition.y), timestamp: timestamp
+            )
+            filters[joint.name] = jointFilter
+            return DetectedJoint(
+                name: joint.name,
+                normalizedPosition: CGPoint(x: sx, y: sy),
+                confidence: joint.confidence
+            )
+        }
+        return DetectedPose(joints: smoothedJoints)
+    }
+
+    /// Forgets all joint history. Call when the underlying clip changes or
+    /// detection is restarted.
+    mutating func reset() {
+        filters.removeAll()
+        lastTimestamp = nil
+    }
+}

--- a/StepBack/Services/PoseStreamCoordinator.swift
+++ b/StepBack/Services/PoseStreamCoordinator.swift
@@ -54,6 +54,10 @@ final class PoseStreamCoordinator: ObservableObject {
     private var tickTask: Task<Void, Never>?
     private var lastSuccessTime: Date?
     private var lastProcessedTime: CMTime?
+    /// Per-joint One-Euro smoothing applied to every detected pose before
+    /// publishing, so the rendered skeleton (and anything derived from it)
+    /// stops shimmering frame-to-frame.
+    private var smoother = PoseSmoother()
     /// Cached `CGImagePropertyOrientation` derived from the current player
     /// item's video track preferredTransform. Set asynchronously after the
     /// item swaps; until resolved we default to `.up`, which matches the
@@ -85,6 +89,7 @@ final class PoseStreamCoordinator: ObservableObject {
         lastSuccessTime = nil
         lastProcessedTime = nil
         poseAge = .infinity
+        smoother.reset()
         attachOutputIfNeeded()
         tickTask = Task { [weak self] in
             while !Task.isCancelled {
@@ -103,6 +108,7 @@ final class PoseStreamCoordinator: ObservableObject {
         lastSuccessTime = nil
         lastProcessedTime = nil
         poseAge = .infinity
+        smoother.reset()
         detachOutput()
     }
 
@@ -137,6 +143,8 @@ final class PoseStreamCoordinator: ObservableObject {
         // Reset cached imageSize so it gets re-derived with the new
         // orientation on the next pixel-buffer copy.
         imageSize = nil
+        // New clip → forget joint smoothing history.
+        smoother.reset()
         orientationTask?.cancel()
         orientationTask = Task { [weak self] in
             let resolved = await Self.resolveOrientation(for: item)
@@ -211,10 +219,18 @@ final class PoseStreamCoordinator: ObservableObject {
         switch result {
         case .success(let detected):
             if let detected {
-                self.pose = detected
+                // Smooth against media time so joint velocity (and the
+                // adaptive cutoff) is a stable physical quantity regardless
+                // of playback speed; a large media-time jump (scrub) resets
+                // the filters inside the smoother.
+                let smoothed = smoother.smooth(
+                    detected,
+                    timestamp: CMTimeGetSeconds(time)
+                )
+                self.pose = smoothed
                 self.lastSuccessTime = Date()
                 self.poseAge = 0
-                self.status = .detected(jointCount: detected.joints.count)
+                self.status = .detected(jointCount: smoothed.joints.count)
             } else {
                 // Vision returned no observation — the dancer might have
                 // turned away, gone partially off-screen, or the frame's

--- a/StepBackTests/OneEuroFilterTests.swift
+++ b/StepBackTests/OneEuroFilterTests.swift
@@ -1,0 +1,90 @@
+@testable import StepBack
+import XCTest
+
+final class OneEuroFilterTests: XCTestCase {
+
+    private let accuracy = 1e-9
+
+    // MARK: - Pass-through cases
+
+    func testFirstSamplePassesThroughUnchanged() {
+        var filter = OneEuroFilter(minCutoff: 1.0, beta: 0.5)
+        XCTAssertEqual(filter.filter(0.42, timestamp: 0), 0.42, accuracy: accuracy)
+    }
+
+    func testConstantSignalStaysConstant() {
+        var filter = OneEuroFilter(minCutoff: 1.0, beta: 0.5)
+        var dt = 0.0
+        for _ in 0..<30 {
+            let out = filter.filter(0.5, timestamp: dt)
+            XCTAssertEqual(out, 0.5, accuracy: accuracy)
+            dt += 0.06
+        }
+    }
+
+    func testNonMonotonicTimestampPassesThrough() {
+        var filter = OneEuroFilter(minCutoff: 1.0, beta: 0.5)
+        _ = filter.filter(0.1, timestamp: 1.0)
+        _ = filter.filter(0.2, timestamp: 1.06)
+        // Time goes backwards (a seek): the new value should pass through,
+        // not blend with history across the discontinuity.
+        let out = filter.filter(0.9, timestamp: 0.5)
+        XCTAssertEqual(out, 0.9, accuracy: accuracy)
+    }
+
+    func testSameTimestampPassesThrough() {
+        var filter = OneEuroFilter(minCutoff: 1.0, beta: 0.5)
+        _ = filter.filter(0.1, timestamp: 1.0)
+        let out = filter.filter(0.8, timestamp: 1.0)  // dt == 0
+        XCTAssertEqual(out, 0.8, accuracy: accuracy)
+    }
+
+    // MARK: - Smoothing behaviour
+
+    func testSmoothedOutputLagsTowardNewValueWithoutOvershoot() {
+        // Step from 0 to 1; output should move toward 1 monotonically and
+        // never exceed it.
+        var filter = OneEuroFilter(minCutoff: 1.0, beta: 0.0)
+        _ = filter.filter(0.0, timestamp: 0.0)
+        var previous = 0.0
+        var t = 0.06
+        for _ in 0..<40 {
+            let out = filter.filter(1.0, timestamp: t)
+            XCTAssertGreaterThanOrEqual(out, previous - accuracy, "should not move backward")
+            XCTAssertLessThanOrEqual(out, 1.0 + accuracy, "should not overshoot")
+            previous = out
+            t += 0.06
+        }
+        XCTAssertGreaterThan(previous, 0.9, "should converge close to the target")
+    }
+
+    func testReducesAlternatingJitter() {
+        // Small-amplitude alternation around a mean, like real Vision noise.
+        // The filter should shrink the swing.
+        var filter = OneEuroFilter(minCutoff: 1.0, beta: 0.5)
+        let mean = 0.5
+        let amplitude = 0.02
+        var t = 0.0
+        var lastOutputs: [Double] = []
+        for i in 0..<40 {
+            let raw = mean + (i % 2 == 0 ? amplitude : -amplitude)
+            let out = filter.filter(raw, timestamp: t)
+            if i >= 30 { lastOutputs.append(out) }
+            t += 0.06
+        }
+        let maxDeviation = lastOutputs.map { abs($0 - mean) }.max() ?? .infinity
+        XCTAssertLessThan(
+            maxDeviation, amplitude,
+            "smoothed swing (\(maxDeviation)) should be smaller than the raw amplitude (\(amplitude))"
+        )
+    }
+
+    func testResetForgetsHistory() {
+        var filter = OneEuroFilter(minCutoff: 1.0, beta: 0.5)
+        _ = filter.filter(0.1, timestamp: 0.0)
+        _ = filter.filter(0.1, timestamp: 0.06)
+        filter.reset()
+        // After reset the next sample is a fresh first sample → pass-through.
+        XCTAssertEqual(filter.filter(0.95, timestamp: 0.12), 0.95, accuracy: accuracy)
+    }
+}

--- a/StepBackTests/PoseSmootherTests.swift
+++ b/StepBackTests/PoseSmootherTests.swift
@@ -1,0 +1,101 @@
+@testable import StepBack
+import CoreGraphics
+import Vision
+import XCTest
+
+final class PoseSmootherTests: XCTestCase {
+
+    private func pose(
+        _ entries: [(VNHumanBodyPoseObservation.JointName, CGPoint)],
+        confidence: Float = 0.9
+    ) -> DetectedPose {
+        DetectedPose(joints: entries.map { name, point in
+            DetectedJoint(name: name, normalizedPosition: point, confidence: confidence)
+        })
+    }
+
+    func testFirstPosePassesThroughUnchanged() {
+        var smoother = PoseSmoother()
+        let input = pose([(.leftWrist, CGPoint(x: 0.3, y: 0.7))])
+        let output = smoother.smooth(input, timestamp: 0)
+        let joint = output.joints.first { $0.name == .leftWrist }
+        XCTAssertEqual(joint?.normalizedPosition.x ?? -1, 0.3, accuracy: 1e-9)
+        XCTAssertEqual(joint?.normalizedPosition.y ?? -1, 0.7, accuracy: 1e-9)
+    }
+
+    func testConfidenceIsPreserved() {
+        var smoother = PoseSmoother()
+        let input = pose([(.nose, CGPoint(x: 0.5, y: 0.5))], confidence: 0.42)
+        let output = smoother.smooth(input, timestamp: 0)
+        XCTAssertEqual(output.joints.first?.confidence ?? -1, 0.42, accuracy: 1e-6)
+    }
+
+    func testJointsSmoothedIndependently() {
+        var smoother = PoseSmoother(minCutoff: 1.0, beta: 0.0)
+        _ = smoother.smooth(
+            pose([
+                (.leftWrist, CGPoint(x: 0.0, y: 0.0)),
+                (.rightWrist, CGPoint(x: 1.0, y: 1.0)),
+            ]),
+            timestamp: 0
+        )
+        // Move only the left wrist; the right should stay put (within the
+        // filter's own steady-state, which for an unchanged input is exact).
+        let out = smoother.smooth(
+            pose([
+                (.leftWrist, CGPoint(x: 0.5, y: 0.5)),
+                (.rightWrist, CGPoint(x: 1.0, y: 1.0)),
+            ]),
+            timestamp: 0.06
+        )
+        let left = out.joints.first { $0.name == .leftWrist }!
+        let right = out.joints.first { $0.name == .rightWrist }!
+        // Left lags toward its new position (smoothed, so strictly between).
+        XCTAssertGreaterThan(left.normalizedPosition.x, 0.0)
+        XCTAssertLessThan(left.normalizedPosition.x, 0.5)
+        // Right was constant → unchanged.
+        XCTAssertEqual(right.normalizedPosition.x, 1.0, accuracy: 1e-9)
+        XCTAssertEqual(right.normalizedPosition.y, 1.0, accuracy: 1e-9)
+    }
+
+    func testLargeTimeGapResetsAndPassesThrough() {
+        var smoother = PoseSmoother(resetGap: 0.4)
+        _ = smoother.smooth(pose([(.nose, CGPoint(x: 0.1, y: 0.1))]), timestamp: 0)
+        // Jump well past resetGap — treated as a seek, so the new pose
+        // passes through unsmoothed.
+        let out = smoother.smooth(
+            pose([(.nose, CGPoint(x: 0.9, y: 0.9))]),
+            timestamp: 5.0
+        )
+        let nose = out.joints.first!
+        XCTAssertEqual(nose.normalizedPosition.x, 0.9, accuracy: 1e-9)
+        XCTAssertEqual(nose.normalizedPosition.y, 0.9, accuracy: 1e-9)
+    }
+
+    func testBackwardTimestampResets() {
+        var smoother = PoseSmoother()
+        _ = smoother.smooth(pose([(.nose, CGPoint(x: 0.1, y: 0.1))]), timestamp: 2.0)
+        let out = smoother.smooth(
+            pose([(.nose, CGPoint(x: 0.8, y: 0.8))]),
+            timestamp: 1.0  // backward
+        )
+        XCTAssertEqual(out.joints.first?.normalizedPosition.x ?? -1, 0.8, accuracy: 1e-9)
+    }
+
+    func testNewlyAppearingJointPassesThroughOnFirstSight() {
+        var smoother = PoseSmoother(minCutoff: 1.0, beta: 0.0)
+        _ = smoother.smooth(pose([(.leftWrist, CGPoint(x: 0.2, y: 0.2))]), timestamp: 0)
+        // rightWrist shows up for the first time on the second frame — it
+        // has no history, so it should pass through exactly.
+        let out = smoother.smooth(
+            pose([
+                (.leftWrist, CGPoint(x: 0.2, y: 0.2)),
+                (.rightWrist, CGPoint(x: 0.8, y: 0.6)),
+            ]),
+            timestamp: 0.06
+        )
+        let right = out.joints.first { $0.name == .rightWrist }!
+        XCTAssertEqual(right.normalizedPosition.x, 0.8, accuracy: 1e-9)
+        XCTAssertEqual(right.normalizedPosition.y, 0.6, accuracy: 1e-9)
+    }
+}


### PR DESCRIPTION
Closes #75. First step of the weight-stacking arc — the foundation everything else needs.

## Why now

The skeleton shimmers frame-to-frame even when the dancer is nearly still: Vision's per-frame joint estimates carry a few pixels of noise. Rendered raw it looks bad, but the real problem is that **center of mass, plumb line, and joint velocity all require differentiating joint position** — and differentiating a noisy signal amplifies the noise into garbage. So smoothing has to land before any of the weight-stacking geometry.

## What

- **`OneEuroFilter`** — pure scalar adaptive low-pass (Casiez, Roussel & Vogel, 2012). The cutoff frequency rises with the signal's speed, so it removes jitter at rest but stays responsive during fast motion. A plain fixed-cutoff low-pass would lag every quick limb; this doesn't. First sample and any non-monotonic timestep pass through unchanged (clean behaviour on seeks).
- **`PoseSmoother`** — independent x/y filters per joint name. A joint that drops out and returns picks up a fresh filter. Resets all filters on a time gap > 0.4s, so scrubbing snaps the skeleton to the new frame instead of smearing a path between two unrelated poses. Params tuned for Vision's normalized 0…1 coordinates (`beta = 0.5`, higher than a pixel-space default so fast limbs don't lag).
- **`PoseStreamCoordinator`** smooths each detected pose using **media time** as the filter clock — so joint velocity (and therefore the adaptive cutoff) is a stable physical quantity regardless of playback speed. At 0.5× you get more smoothing (you're scrutinizing); at 1.5× less. Smoother resets on start/stop and on item swap.

## Tests

133 pass (was 120). 13 new:
- 7 `OneEuroFilterTests`: pass-through first sample, constant-stays-constant, backward/duplicate timestamp pass-through, step response (monotonic, no overshoot, converges), jitter reduction, reset.
- 6 `PoseSmootherTests`: pass-through first pose, confidence preserved, joints smoothed independently, large-gap reset, backward-timestamp reset, newly-appearing joint passes through.

## Next in the arc

CoM plumb-line overlay → per-clip pose cache → anchor (5&6) stacking analysis → CoM trajectory trail.
