### PR TITLE
Center-of-mass plumb line for weight stacking

### DIFF
--- a/StepBack/Services/WeightStackingEvaluator.swift
+++ b/StepBack/Services/WeightStackingEvaluator.swift
@@ -59,4 +59,65 @@ enum WeightStackingEvaluator {
         let threshold: Double = .pi / 4   // 45° = full red
         return max(0, 1.0 - angleFromAxis / threshold)
     }
+
+    // MARK: - Center of mass
+
+    /// Estimates a 2-D centre of mass from the torso joints. The pelvis
+    /// carries the bulk of body mass, so the hip midpoint is weighted more
+    /// than the shoulder midpoint; the blend lands roughly at the navel,
+    /// which is a serviceable single-camera CoM proxy.
+    ///
+    /// Requires *both* joints of a pair to use that pair — a lone hip joint
+    /// is not the pelvis centre, and trusting it would skew the CoM toward
+    /// whichever side Vision happened to see. Returns nil when neither pair
+    /// is fully available.
+    static func centerOfMass(
+        leftHip: CGPoint?, rightHip: CGPoint?,
+        leftShoulder: CGPoint?, rightShoulder: CGPoint?,
+        hipWeight: Double = 0.65
+    ) -> CGPoint? {
+        let hipMid = midpoint(leftHip, rightHip)
+        let shoulderMid = midpoint(leftShoulder, rightShoulder)
+
+        switch (hipMid, shoulderMid) {
+        case let (hip?, shoulder?):
+            let w = max(0, min(1, hipWeight))
+            return CGPoint(
+                x: hip.x * w + shoulder.x * (1 - w),
+                y: hip.y * w + shoulder.y * (1 - w)
+            )
+        case let (hip?, nil):
+            return hip
+        case let (nil, shoulder?):
+            return shoulder
+        case (nil, nil):
+            return nil
+        }
+    }
+
+    /// How well the centre of mass is stacked over a foot, measured
+    /// horizontally. 1.0 = directly over an ankle (stacked), 0.5 = midway
+    /// between the feet (weight split / uncommitted), 0.0 = a full
+    /// stance-width or more outside the nearer foot (off balance).
+    ///
+    /// Normalising by stance width makes the score scale-free: a wide base
+    /// and a narrow base both read "stacked" when the CoM is over a foot.
+    /// `minStance` floors the denominator so feet-together stances don't
+    /// divide by ~zero.
+    static func comStackingScore(
+        comX: CGFloat,
+        leftAnkleX: CGFloat,
+        rightAnkleX: CGFloat,
+        minStance: CGFloat = 1
+    ) -> Double {
+        let stance = abs(leftAnkleX - rightAnkleX)
+        let reference = max(stance, minStance)
+        let nearest = min(abs(comX - leftAnkleX), abs(comX - rightAnkleX))
+        return max(0, 1 - Double(nearest / reference))
+    }
+
+    private static func midpoint(_ a: CGPoint?, _ b: CGPoint?) -> CGPoint? {
+        guard let a, let b else { return nil }
+        return CGPoint(x: (a.x + b.x) / 2, y: (a.y + b.y) / 2)
+    }
 }

--- a/StepBack/Views/PoseOverlay.swift
+++ b/StepBack/Views/PoseOverlay.swift
@@ -50,6 +50,7 @@ struct PoseOverlay: View {
                 Canvas { context, _ in
                     drawBones(pose: pose, displayRect: rect, context: context)
                     drawJoints(pose: pose, displayRect: rect, context: context)
+                    drawCenterOfMass(pose: pose, displayRect: rect, context: context)
                 }
                 .opacity(freshnessOpacity)
             }
@@ -128,6 +129,88 @@ struct PoseOverlay: View {
                 Path(ellipseIn: rect),
                 with: .color(Color.white.opacity(alpha * 0.85))
             )
+        }
+    }
+
+    /// Draws the centre-of-mass plumb line — the actual weight-stacking
+    /// cue. A vertical line dropped from the estimated CoM shows, at a
+    /// glance, whether the dancer's mass is stacked over a foot. The line
+    /// is coloured by `comStackingScore`: green over a foot, yellow midway
+    /// between the feet, red leaning past the base of support.
+    private func drawCenterOfMass(
+        pose: DetectedPose,
+        displayRect: CGRect,
+        context: GraphicsContext
+    ) {
+        let lookup = Dictionary(
+            uniqueKeysWithValues: pose.joints.map { ($0.name, $0) }
+        )
+        func point(_ name: VNHumanBodyPoseObservation.JointName) -> CGPoint? {
+            guard let joint = lookup[name] else { return nil }
+            return PoseCoordinateTransform.viewPoint(
+                normalizedImagePoint: joint.normalizedPosition,
+                displayRect: displayRect
+            )
+        }
+
+        guard let com = WeightStackingEvaluator.centerOfMass(
+            leftHip: point(.leftHip),
+            rightHip: point(.rightHip),
+            leftShoulder: point(.leftShoulder),
+            rightShoulder: point(.rightShoulder)
+        ) else { return }
+
+        let leftAnkle = point(.leftAnkle)
+        let rightAnkle = point(.rightAnkle)
+
+        // Colour the line by stacking quality when we can see both feet;
+        // otherwise stay neutral rather than make a claim we can't support.
+        let tint: Color
+        if let leftAnkle, let rightAnkle {
+            let score = WeightStackingEvaluator.comStackingScore(
+                comX: com.x,
+                leftAnkleX: leftAnkle.x,
+                rightAnkleX: rightAnkle.x,
+                minStance: max(1, displayRect.width * 0.02)
+            )
+            tint = Color.stackingColor(for: score)
+        } else {
+            tint = Theme.Color.textPrimary
+        }
+
+        // Drop the plumb line from the CoM to the lower foot (or the bottom
+        // of the frame if feet aren't visible), so the eye can compare the
+        // line against the base of support.
+        let bottomY = [leftAnkle?.y, rightAnkle?.y]
+            .compactMap { $0 }
+            .max() ?? displayRect.maxY
+
+        var line = Path()
+        line.move(to: CGPoint(x: com.x, y: com.y))
+        line.addLine(to: CGPoint(x: com.x, y: max(com.y, bottomY)))
+        context.stroke(
+            line,
+            with: .color(tint.opacity(0.9)),
+            style: StrokeStyle(lineWidth: 2, dash: [6, 5])
+        )
+
+        // CoM marker — a ringed dot so it stands apart from the white joints.
+        let r: CGFloat = 6
+        let comRect = CGRect(x: com.x - r, y: com.y - r, width: r * 2, height: r * 2)
+        context.fill(Path(ellipseIn: comRect), with: .color(tint))
+        context.stroke(
+            Path(ellipseIn: comRect.insetBy(dx: -2, dy: -2)),
+            with: .color(.white.opacity(0.9)),
+            lineWidth: 1.5
+        )
+
+        // Base-of-support tick at each visible ankle, so "is the line over a
+        // foot?" is answerable by eye.
+        for ankle in [leftAnkle, rightAnkle].compactMap({ $0 }) {
+            var tick = Path()
+            tick.move(to: CGPoint(x: ankle.x - 10, y: ankle.y))
+            tick.addLine(to: CGPoint(x: ankle.x + 10, y: ankle.y))
+            context.stroke(tick, with: .color(tint.opacity(0.8)), lineWidth: 2)
         }
     }
 

--- a/StepBackTests/WeightStackingEvaluatorTests.swift
+++ b/StepBackTests/WeightStackingEvaluatorTests.swift
@@ -116,4 +116,112 @@ final class WeightStackingEvaluatorTests: XCTestCase {
         )
         XCTAssertEqual(score, 1.0, accuracy: accuracy)
     }
+
+    // MARK: - Center of mass
+
+    func testCenterOfMassBlendsHipAndShoulderWeightedToHip() {
+        // Hips at y=200, shoulders at y=100; default hipWeight 0.65 →
+        // y = 200*0.65 + 100*0.35 = 165. x is the same column so stays 50.
+        let com = WeightStackingEvaluator.centerOfMass(
+            leftHip: CGPoint(x: 40, y: 200),
+            rightHip: CGPoint(x: 60, y: 200),
+            leftShoulder: CGPoint(x: 40, y: 100),
+            rightShoulder: CGPoint(x: 60, y: 100)
+        )
+        XCTAssertEqual(com?.x ?? -1, 50, accuracy: accuracy)
+        XCTAssertEqual(com?.y ?? -1, 165, accuracy: accuracy)
+    }
+
+    func testCenterOfMassUsesHipsOnlyWhenShouldersMissing() {
+        let com = WeightStackingEvaluator.centerOfMass(
+            leftHip: CGPoint(x: 40, y: 200),
+            rightHip: CGPoint(x: 60, y: 200),
+            leftShoulder: nil,
+            rightShoulder: nil
+        )
+        XCTAssertEqual(com?.x ?? -1, 50, accuracy: accuracy)
+        XCTAssertEqual(com?.y ?? -1, 200, accuracy: accuracy)
+    }
+
+    func testCenterOfMassUsesShouldersOnlyWhenHipsMissing() {
+        let com = WeightStackingEvaluator.centerOfMass(
+            leftHip: nil,
+            rightHip: nil,
+            leftShoulder: CGPoint(x: 40, y: 100),
+            rightShoulder: CGPoint(x: 60, y: 100)
+        )
+        XCTAssertEqual(com?.x ?? -1, 50, accuracy: accuracy)
+        XCTAssertEqual(com?.y ?? -1, 100, accuracy: accuracy)
+    }
+
+    func testCenterOfMassRequiresBothJointsOfAPair() {
+        // A lone hip + lone shoulder isn't enough for either midpoint.
+        let com = WeightStackingEvaluator.centerOfMass(
+            leftHip: CGPoint(x: 40, y: 200),
+            rightHip: nil,
+            leftShoulder: CGPoint(x: 40, y: 100),
+            rightShoulder: nil
+        )
+        XCTAssertNil(com)
+    }
+
+    func testCenterOfMassNilWhenNothingAvailable() {
+        XCTAssertNil(WeightStackingEvaluator.centerOfMass(
+            leftHip: nil, rightHip: nil, leftShoulder: nil, rightShoulder: nil
+        ))
+    }
+
+    // MARK: - CoM stacking score
+
+    func testStackingScoreOneOverLeftAnkle() {
+        let score = WeightStackingEvaluator.comStackingScore(
+            comX: 100, leftAnkleX: 100, rightAnkleX: 200
+        )
+        XCTAssertEqual(score, 1.0, accuracy: accuracy)
+    }
+
+    func testStackingScoreOneOverRightAnkle() {
+        let score = WeightStackingEvaluator.comStackingScore(
+            comX: 200, leftAnkleX: 100, rightAnkleX: 200
+        )
+        XCTAssertEqual(score, 1.0, accuracy: accuracy)
+    }
+
+    func testStackingScoreHalfAtMidpoint() {
+        // CoM dead-centre between feet → nearest ankle is half a stance away
+        // → 0.5 (weight split, not stacked).
+        let score = WeightStackingEvaluator.comStackingScore(
+            comX: 150, leftAnkleX: 100, rightAnkleX: 200
+        )
+        XCTAssertEqual(score, 0.5, accuracy: accuracy)
+    }
+
+    func testStackingScoreZeroAFullStanceOutside() {
+        // One stance-width beyond the right ankle.
+        let score = WeightStackingEvaluator.comStackingScore(
+            comX: 300, leftAnkleX: 100, rightAnkleX: 200
+        )
+        XCTAssertEqual(score, 0.0, accuracy: accuracy)
+    }
+
+    func testStackingScoreClampsBelowZeroWayOutside() {
+        let score = WeightStackingEvaluator.comStackingScore(
+            comX: 1000, leftAnkleX: 100, rightAnkleX: 200
+        )
+        XCTAssertEqual(score, 0.0, accuracy: accuracy)
+    }
+
+    func testStackingScoreFeetTogetherUsesMinStanceFloor() {
+        // Ankles coincide; minStance floors the denominator so we don't
+        // divide by zero. CoM exactly on the foot → 1.
+        let onFoot = WeightStackingEvaluator.comStackingScore(
+            comX: 100, leftAnkleX: 100, rightAnkleX: 100, minStance: 10
+        )
+        XCTAssertEqual(onFoot, 1.0, accuracy: accuracy)
+        // Off by a full floor → 0.
+        let offFoot = WeightStackingEvaluator.comStackingScore(
+            comX: 110, leftAnkleX: 100, rightAnkleX: 100, minStance: 10
+        )
+        XCTAssertEqual(offFoot, 0.0, accuracy: accuracy)
+    }
 }


### PR DESCRIPTION
Second step of the weight-stacking arc (after #76 smoothing). This draws the **actual** stacking cue — the colored bones were a geometric proxy; the plumb line answers the real West Coast Swing question: *is your mass stacked over a foot?*

## What you'll see

A vertical dashed **plumb line** dropped from the estimated center of mass, plus a ringed CoM dot and small ticks at each ankle (the base of support). The line is colored:

- 🟢 **green** — CoM is over a foot (stacked)
- 🟡 **yellow** — CoM is midway between the feet (weight split / uncommitted)
- 🔴 **red** — CoM is leaning past the base of support (off balance)

Read it by eye: is the dashed line landing on an ankle tick, or floating between/outside them?

## The math (pure, tested)

Two new functions on `WeightStackingEvaluator`:

- **`centerOfMass(...)`** — weighted blend of the hip midpoint (0.65) and shoulder midpoint (0.35), landing roughly at the navel — a serviceable single-camera CoM proxy. Requires *both* joints of a pair to use that pair (a lone hip isn't the pelvis center and would skew the estimate). Falls back to whichever pair is available; nil if neither.
- **`comStackingScore(...)`** — horizontal stacking quality, normalized by stance width so it's scale-free (wide and narrow bases both read "stacked" when the CoM is over a foot). 1.0 over an ankle, 0.5 at the midpoint, 0 a full stance-width outside. `minStance` floors the denominator for feet-together stances.

Rendering happens in **view space** (not normalized) so the horizontal CoM-vs-ankle comparison isn't distorted by the video's aspect ratio.

## Why it depends on #76

CoM is a difference of joint positions, and the stacking score keys off small horizontal offsets. On raw (unsmoothed) joints those would jitter wildly. Smoothing had to land first — which it did in #76.

## Honest limits (still v2 territory)

- It does **not** know which foot is *posted* (weight-bearing). It scores against the *nearer* foot. Identifying the posted foot needs temporal tracking — the next steps in the arc.
- During a genuine weight transfer the line correctly passes through yellow; that's not an error, it's the transfer.
- Neutral (white) when both ankles aren't visible, rather than claiming a score it can't support.

## Tests

144 pass (was 133). 11 new: CoM blend (hip+shoulder weighting, single-pair fallbacks, incomplete-pair → nil), and the stacking-score curve (over each ankle, midpoint = 0.5, full-stance-outside = 0, clamp, feet-together floor).

## Next in the arc

Per-clip pose cache → posted-foot detection → anchor (5&6) stacking analysis → CoM trajectory trail.
