### PR TITLE
Stop playback on leave + keep HDR display under pose overlay

### DIFF
--- a/StepBack/Services/PoseStreamCoordinator.swift
+++ b/StepBack/Services/PoseStreamCoordinator.swift
@@ -72,9 +72,14 @@ final class PoseStreamCoordinator: ObservableObject {
     ) {
         self.player = player
         self.detector = detector
-        videoOutput = AVPlayerItemVideoOutput(pixelBufferAttributes: [
-            kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32BGRA)
-        ])
+        // Native output settings (nil) rather than forcing SDR 32BGRA.
+        // Forcing an 8-bit SDR format makes iOS collapse the *displayed*
+        // AVPlayerLayer to SDR for HDR (Dolby Vision) source clips — which
+        // most iPhone footage is — and the HDR→SDR tone-map visibly lifts
+        // mid-tones ("the video got brighter when pose is on"). Letting the
+        // output vend native frames preserves the HDR display pipeline;
+        // Vision's VNImageRequestHandler accepts the native pixel buffers.
+        videoOutput = AVPlayerItemVideoOutput(outputSettings: nil)
     }
 
     deinit {

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -134,6 +134,13 @@ struct PracticeView: View {
         }
         .onAppear { vm.enableNowPlaying(for: clip) }
         .onDisappear {
+            // Stop playback when leaving the screen. Without this the player
+            // keeps going after you navigate back (audio session is .playback
+            // + Background Audio), and opening another clip stacks a second
+            // player over the first → overlapping audio. onDisappear fires on
+            // *navigation*, not on app-backgrounding, so locking the phone
+            // still keeps audio playing as intended.
+            vm.pause()
             vm.disableNowPlaying()
             poseCoordinator.stop()
         }


### PR DESCRIPTION
Two playback bugs reported from device.

## 1. Audio doesn't stop when you leave a clip

`PracticeView.onDisappear` tore down Now Playing and the pose pipeline but **never paused the player**. With the `.playback` audio session + Background Audio capability (#46), the player just kept going after you navigated back — and opening another clip started a *second* player over the first, so you got overlapping audio.

**Fix:** `vm.pause()` in `onDisappear`.

This is safe for the lock-screen/background audio feature: `onDisappear` fires on **navigation**, not on app-backgrounding. So:
- Navigate back to Library → pause ✓
- Lock the phone → app backgrounds, view stays in hierarchy → `onDisappear` does *not* fire → audio keeps playing ✓ (still works as #46 intended)

## 2. Video brightens when pose detection is on

The pose pipeline's `AVPlayerItemVideoOutput` requested SDR **32BGRA** frames. For **HDR (Dolby Vision)** source clips — which is most iPhone footage — attaching an SDR output makes iOS collapse the *displayed* `AVPlayerLayer` to SDR, and the HDR→SDR tone-map lifts mid-tones. That's the "brightening."

**Fix:** switch the output to native settings (`outputSettings: nil`), which preserves the HDR display pipeline. Vision's `VNImageRequestHandler` accepts the native pixel buffers.

⚠️ **Needs on-device validation on HDR footage** — I can't reproduce HDR on the simulator. Please confirm two things when you test: (a) the brightening is gone, and (b) pose detection still produces a skeleton. If detection regresses on the native format, the fallback is to request a 10-bit HDR-capable format (`x420`) instead of native.

## Tests

144 pass (no behavior covered by unit tests here — both are AVFoundation-level config/lifecycle).
