### PR TITLE
Lock the pose skeleton to one dancer

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		76D520F6EC5A0A8E57C8AAA1 /* BeatDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6BC077A9FA8B51D07C178A0 /* BeatDetectorTests.swift */; };
 		782B609F039BD291571F9CB2 /* PoseCoordinateTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75D7B3643B17B81DF4B8A3D8 /* PoseCoordinateTransform.swift */; };
 		7FA3BBA0113FDF3282819E84 /* PracticePlayerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */; };
+		8485142C3D308FCFF6821FC9 /* PoseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3B9912F4A07E233D008D07 /* PoseTracker.swift */; };
 		852871D2A9B846C1A484DD59 /* WeightStackingEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90EF44647A178F72AF7CEBDB /* WeightStackingEvaluator.swift */; };
 		8772C73FA1983B9E8A39FAD8 /* Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5445312DC1A378A65F963DD7 /* Schema.swift */; };
 		9799CACB6C924AC1940D9FE3 /* StepBackMigrationPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808127290713ACE9855DA35E /* StepBackMigrationPlanTests.swift */; };
@@ -48,6 +49,7 @@
 		C97E59DA25A51E16ECA03607 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C112AEA59633E85CF8267D /* ThemeTests.swift */; };
 		CBA5E26E730D69F9A3E4944B /* TrimAnnotationShifter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71643D36F7F8D028B560F012 /* TrimAnnotationShifter.swift */; };
 		CC6F98E7716925F88449689A /* PhotosServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5505E62D217CB6AA3579A6D /* PhotosServiceTests.swift */; };
+		D5258BD41CFB10582AFE2826 /* PoseTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A00175844257072F77DB5E /* PoseTrackerTests.swift */; };
 		D59006BDF41C10B002F97FE8 /* PoseOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08505D0FA11E6637197AF8EC /* PoseOverlay.swift */; };
 		D8739042EECB4AE2C7804C41 /* OriginalImportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D1395E84111ADD80CC22565 /* OriginalImportService.swift */; };
 		D9873262DD68100D8D3C1021 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 462E264B215595E9EC3D1C4A /* Assets.xcassets */; };
@@ -119,8 +121,10 @@
 		C35987D9825155E131A40950 /* PracticeControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeControls.swift; sourceTree = "<group>"; };
 		C59BD8F65AE46261EEFD4F69 /* BeatDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeatDetector.swift; sourceTree = "<group>"; };
 		CC6BAE20433D2ED45F00AD41 /* PracticeBeatUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeBeatUI.swift; sourceTree = "<group>"; };
+		D3A00175844257072F77DB5E /* PoseTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoseTrackerTests.swift; sourceTree = "<group>"; };
 		D8F8476EAB523378C1F1E046 /* PhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosService.swift; sourceTree = "<group>"; };
 		DB3B8C1BB7ACE2D1C13C7200 /* StepTimingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepTimingTests.swift; sourceTree = "<group>"; };
+		DB3B9912F4A07E233D008D07 /* PoseTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoseTracker.swift; sourceTree = "<group>"; };
 		E56B6CE778D3BD0C5B1B248B /* KeepScreenAwake.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeepScreenAwake.swift; sourceTree = "<group>"; };
 		EAF9D9B68E730BA51C86D70A /* TrimView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimView.swift; sourceTree = "<group>"; };
 		EB991AFC28C64366954E1D19 /* TrimAnnotationShifterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimAnnotationShifterTests.swift; sourceTree = "<group>"; };
@@ -180,6 +184,7 @@
 				ED02929698766149F5A683B1 /* PoseCoordinateTransformTests.swift */,
 				284F5B49794793B83D590351 /* PoseOrientationTests.swift */,
 				8AAC69A2C2F4F581525FFA41 /* PoseSmootherTests.swift */,
+				D3A00175844257072F77DB5E /* PoseTrackerTests.swift */,
 				16E676751B59ED083837CE39 /* SpeedFormatterTests.swift */,
 				808127290713ACE9855DA35E /* StepBackMigrationPlanTests.swift */,
 				DB3B8C1BB7ACE2D1C13C7200 /* StepTimingTests.swift */,
@@ -205,6 +210,7 @@
 				AB61ACAF01042F0783B3CBD2 /* PoseOrientation.swift */,
 				7B555006BB3DDAF7885AA331 /* PoseSmoother.swift */,
 				A5844567C104B87D338953E6 /* PoseStreamCoordinator.swift */,
+				DB3B9912F4A07E233D008D07 /* PoseTracker.swift */,
 				543153BE7C96EE23F43CE81E /* PracticePlayerViewModel.swift */,
 				94AAA488969D7CF77497859D /* SegmentThumbnailGenerator.swift */,
 				0265ABC8E91AF4657EB95F83 /* StepTiming.swift */,
@@ -361,6 +367,7 @@
 				D59006BDF41C10B002F97FE8 /* PoseOverlay.swift in Sources */,
 				61CF9C7EABDA7AF4C9FE3991 /* PoseSmoother.swift in Sources */,
 				52562CC7EBC717613965ADAB /* PoseStreamCoordinator.swift in Sources */,
+				8485142C3D308FCFF6821FC9 /* PoseTracker.swift in Sources */,
 				03C973FD27336E9DD2EDE507 /* PracticeBeatUI.swift in Sources */,
 				2B90619AE0B5262B774DEAC1 /* PracticeControls.swift in Sources */,
 				7FA3BBA0113FDF3282819E84 /* PracticePlayerViewModel.swift in Sources */,
@@ -395,6 +402,7 @@
 				FF149265E884C202BEF590BE /* PoseCoordinateTransformTests.swift in Sources */,
 				D9AC9EB80E5FBEC30A1AB5B3 /* PoseOrientationTests.swift in Sources */,
 				BAD8216387EC26539DBB6E8C /* PoseSmootherTests.swift in Sources */,
+				D5258BD41CFB10582AFE2826 /* PoseTrackerTests.swift in Sources */,
 				F35848C14CA3DF06A4EBE554 /* SpeedFormatterTests.swift in Sources */,
 				9799CACB6C924AC1940D9FE3 /* StepBackMigrationPlanTests.swift in Sources */,
 				4181110140BD581DBFB0A380 /* StepTimingTests.swift in Sources */,

--- a/StepBack/Services/PoseDetectionService.swift
+++ b/StepBack/Services/PoseDetectionService.swift
@@ -45,10 +45,15 @@ struct PoseDetectionService: Sendable {
         self.confidenceThreshold = confidenceThreshold
     }
 
-    func detect(
+    /// Detects every person Vision finds in the frame, returning one
+    /// `DetectedPose` per observation that has at least one joint above the
+    /// confidence floor. Selecting *which* person to follow is the caller's
+    /// job (see `PoseTracker`) — doing it here, per-frame and stateless, is
+    /// exactly what made the skeleton jump between dancers.
+    func detectPoses(
         in pixelBuffer: CVPixelBuffer,
         orientation: CGImagePropertyOrientation = .up
-    ) throws -> DetectedPose? {
+    ) throws -> [DetectedPose] {
         let request = VNDetectHumanBodyPoseRequest()
         // Pin to the newest revision the OS supports rather than letting
         // the default float — same model behaviour from device to device,
@@ -64,28 +69,22 @@ struct PoseDetectionService: Sendable {
         } catch {
             throw PoseDetectionError.visionFailed(error.localizedDescription)
         }
-        // Pick the highest overall-confidence observation, not just the
-        // first. With multiple people in frame (common at social dances)
-        // the model returns them in essentially arbitrary order, which
-        // made the skeleton jump between dancers. Highest confidence is
-        // a stable proxy for "the most clearly-visible person."
+
         let observations = request.results ?? []
-        guard let observation = observations.max(by: { $0.confidence < $1.confidence })
-        else { return nil }
-        let allPoints: [VNHumanBodyPoseObservation.JointName: VNRecognizedPoint]
-        do {
-            allPoints = try observation.recognizedPoints(.all)
-        } catch {
-            throw PoseDetectionError.visionFailed(error.localizedDescription)
+        return observations.compactMap { observation -> DetectedPose? in
+            // A single unreadable observation shouldn't fail the whole frame.
+            guard let allPoints = try? observation.recognizedPoints(.all) else {
+                return nil
+            }
+            let joints = allPoints.compactMap { (name, point) -> DetectedJoint? in
+                guard point.confidence >= confidenceThreshold else { return nil }
+                return DetectedJoint(
+                    name: name,
+                    normalizedPosition: point.location,
+                    confidence: point.confidence
+                )
+            }
+            return joints.isEmpty ? nil : DetectedPose(joints: joints)
         }
-        let joints = allPoints.compactMap { (name, point) -> DetectedJoint? in
-            guard point.confidence >= confidenceThreshold else { return nil }
-            return DetectedJoint(
-                name: name,
-                normalizedPosition: point.location,
-                confidence: point.confidence
-            )
-        }
-        return joints.isEmpty ? nil : DetectedPose(joints: joints)
     }
 }

--- a/StepBack/Services/PoseStreamCoordinator.swift
+++ b/StepBack/Services/PoseStreamCoordinator.swift
@@ -58,6 +58,9 @@ final class PoseStreamCoordinator: ObservableObject {
     /// publishing, so the rendered skeleton (and anything derived from it)
     /// stops shimmering frame-to-frame.
     private var smoother = PoseSmoother()
+    /// Locks onto one person across frames so the skeleton doesn't jump
+    /// between dancers when there are several in shot.
+    private var tracker = PoseTracker()
     /// Cached `CGImagePropertyOrientation` derived from the current player
     /// item's video track preferredTransform. Set asynchronously after the
     /// item swaps; until resolved we default to `.up`, which matches the
@@ -95,6 +98,7 @@ final class PoseStreamCoordinator: ObservableObject {
         lastProcessedTime = nil
         poseAge = .infinity
         smoother.reset()
+        tracker.reset()
         attachOutputIfNeeded()
         tickTask = Task { [weak self] in
             while !Task.isCancelled {
@@ -114,6 +118,7 @@ final class PoseStreamCoordinator: ObservableObject {
         lastProcessedTime = nil
         poseAge = .infinity
         smoother.reset()
+        tracker.reset()
         detachOutput()
     }
 
@@ -148,8 +153,9 @@ final class PoseStreamCoordinator: ObservableObject {
         // Reset cached imageSize so it gets re-derived with the new
         // orientation on the next pixel-buffer copy.
         imageSize = nil
-        // New clip → forget joint smoothing history.
+        // New clip → forget joint smoothing history and the tracked person.
         smoother.reset()
+        tracker.reset()
         orientationTask?.cancel()
         orientationTask = Task { [weak self] in
             let resolved = await Self.resolveOrientation(for: item)
@@ -222,14 +228,22 @@ final class PoseStreamCoordinator: ObservableObject {
 
         let result = await detect(pixelBuffer: pixelBuffer, orientation: orientation)
         switch result {
-        case .success(let detected):
-            if let detected {
+        case .success(let candidates):
+            // Lock onto one person across frames. Returns nil only when the
+            // frame had no candidates at all.
+            if let selection = tracker.select(from: candidates) {
+                // On a fresh lock or a re-anchor to a different person, drop
+                // the smoothing history — otherwise the filter would smear a
+                // path between two different bodies.
+                if !selection.isContinuation {
+                    smoother.reset()
+                }
                 // Smooth against media time so joint velocity (and the
                 // adaptive cutoff) is a stable physical quantity regardless
                 // of playback speed; a large media-time jump (scrub) resets
                 // the filters inside the smoother.
                 let smoothed = smoother.smooth(
-                    detected,
+                    selection.pose,
                     timestamp: CMTimeGetSeconds(time)
                 )
                 self.pose = smoothed
@@ -237,10 +251,10 @@ final class PoseStreamCoordinator: ObservableObject {
                 self.poseAge = 0
                 self.status = .detected(jointCount: smoothed.joints.count)
             } else {
-                // Vision returned no observation — the dancer might have
-                // turned away, gone partially off-screen, or the frame's
-                // hard. Don't immediately clear the skeleton; hold for up
-                // to `staleAfter` so a single bad frame doesn't flicker.
+                // No person in this frame — the dancer might have turned
+                // away, gone partially off-screen, or the frame's hard.
+                // Don't immediately clear the skeleton; hold for up to
+                // `staleAfter` so a single bad frame doesn't flicker.
                 handleMissedDetection(reason: .noPerson)
             }
         case .failure(let error):
@@ -287,12 +301,12 @@ final class PoseStreamCoordinator: ObservableObject {
     private func detect(
         pixelBuffer: CVPixelBuffer,
         orientation: CGImagePropertyOrientation
-    ) async -> Result<DetectedPose?, Error> {
+    ) async -> Result<[DetectedPose], Error> {
         let detector = self.detector
         return await withCheckedContinuation { continuation in
             detectionQueue.async {
                 let outcome = Result {
-                    try detector.detect(in: pixelBuffer, orientation: orientation)
+                    try detector.detectPoses(in: pixelBuffer, orientation: orientation)
                 }
                 continuation.resume(returning: outcome)
             }

--- a/StepBack/Services/PoseTracker.swift
+++ b/StepBack/Services/PoseTracker.swift
@@ -1,0 +1,98 @@
+import CoreGraphics
+import Foundation
+
+/// Chooses a single person to follow from the multiple poses Vision returns
+/// per frame, using temporal continuity so the skeleton stops jumping
+/// between dancers. Pure logic, tested directly.
+///
+/// Each frame we pick the candidate whose centroid is nearest the one we
+/// chose last. Only when the nearest candidate is further than `gate` —
+/// meaning the tracked dancer probably left the frame — do we re-anchor to
+/// the most prominent person. The first frame (and any re-anchor) reports
+/// `isContinuation == false` so the caller can reset per-joint smoothing,
+/// which would otherwise smear a path between two different bodies.
+struct PoseTracker {
+
+    struct Selection: Equatable {
+        let pose: DetectedPose
+        /// False on the first lock and on a re-anchor (we switched people);
+        /// true when this frame continues following the same person.
+        let isContinuation: Bool
+    }
+
+    /// Max distance (normalized image units) between this frame's chosen
+    /// centroid and the previous one for them to count as the same person.
+    let gate: Double
+
+    private(set) var lastCentroid: CGPoint?
+
+    init(gate: Double = 0.22) {
+        self.gate = gate
+    }
+
+    /// Returns the pose to display this frame, or nil if there were no
+    /// candidates. An empty frame leaves `lastCentroid` untouched so a brief
+    /// dropout doesn't lose the lock.
+    mutating func select(from candidates: [DetectedPose]) -> Selection? {
+        guard !candidates.isEmpty else { return nil }
+
+        let selection: Selection
+        if let last = lastCentroid,
+           let nearest = candidates.min(by: {
+               Self.distance(Self.centroid($0), last)
+                   < Self.distance(Self.centroid($1), last)
+           }) {
+            if Self.distance(Self.centroid(nearest), last) <= gate {
+                selection = Selection(pose: nearest, isContinuation: true)
+            } else {
+                // Nearest candidate is too far — the tracked dancer likely
+                // left frame. Re-anchor.
+                selection = Selection(pose: mostProminent(candidates), isContinuation: false)
+            }
+        } else {
+            selection = Selection(pose: mostProminent(candidates), isContinuation: false)
+        }
+
+        lastCentroid = Self.centroid(selection.pose)
+        return selection
+    }
+
+    mutating func reset() {
+        lastCentroid = nil
+    }
+
+    /// Most clearly-visible candidate: most joints, ties broken by mean
+    /// confidence. Used for the first lock and for re-anchoring.
+    private func mostProminent(_ candidates: [DetectedPose]) -> DetectedPose {
+        candidates.max { a, b in
+            if a.joints.count != b.joints.count {
+                return a.joints.count < b.joints.count
+            }
+            return Self.meanConfidence(a) < Self.meanConfidence(b)
+        }!
+    }
+
+    /// Average of a pose's joint positions — a cheap, stable centroid.
+    static func centroid(_ pose: DetectedPose) -> CGPoint {
+        guard !pose.joints.isEmpty else { return .zero }
+        let sum = pose.joints.reduce(CGPoint.zero) { acc, joint in
+            CGPoint(
+                x: acc.x + joint.normalizedPosition.x,
+                y: acc.y + joint.normalizedPosition.y
+            )
+        }
+        let n = CGFloat(pose.joints.count)
+        return CGPoint(x: sum.x / n, y: sum.y / n)
+    }
+
+    private static func meanConfidence(_ pose: DetectedPose) -> Float {
+        guard !pose.joints.isEmpty else { return 0 }
+        return pose.joints.reduce(0) { $0 + $1.confidence } / Float(pose.joints.count)
+    }
+
+    private static func distance(_ a: CGPoint, _ b: CGPoint) -> Double {
+        let dx = Double(a.x - b.x)
+        let dy = Double(a.y - b.y)
+        return (dx * dx + dy * dy).squareRoot()
+    }
+}

--- a/StepBackTests/PoseTrackerTests.swift
+++ b/StepBackTests/PoseTrackerTests.swift
@@ -1,0 +1,103 @@
+@testable import StepBack
+import CoreGraphics
+import Vision
+import XCTest
+
+final class PoseTrackerTests: XCTestCase {
+
+    /// Builds a pose whose joints all sit at `center` (so its centroid is
+    /// exactly `center`), with `count` joints at the given confidence.
+    private func pose(
+        at center: CGPoint,
+        count: Int = 4,
+        confidence: Float = 0.9
+    ) -> DetectedPose {
+        let names: [VNHumanBodyPoseObservation.JointName] =
+            [.nose, .leftShoulder, .rightShoulder, .leftHip, .rightHip,
+             .leftWrist, .rightWrist, .leftAnkle]
+        let joints = (0..<count).map { i in
+            DetectedJoint(
+                name: names[i % names.count],
+                normalizedPosition: center,
+                confidence: confidence
+            )
+        }
+        return DetectedPose(joints: joints)
+    }
+
+    func testEmptyCandidatesReturnsNilAndKeepsLock() {
+        var tracker = PoseTracker()
+        _ = tracker.select(from: [pose(at: CGPoint(x: 0.5, y: 0.5))])
+        let before = tracker.lastCentroid
+        XCTAssertNil(tracker.select(from: []))
+        XCTAssertEqual(tracker.lastCentroid, before, "an empty frame must not lose the lock")
+    }
+
+    func testFirstSelectionPicksMostProminentAndIsNotContinuation() {
+        var tracker = PoseTracker()
+        let sparse = pose(at: CGPoint(x: 0.2, y: 0.5), count: 3)
+        let rich = pose(at: CGPoint(x: 0.8, y: 0.5), count: 7)
+        let sel = tracker.select(from: [sparse, rich])
+        XCTAssertEqual(sel?.pose, rich, "first lock should pick the most-joints candidate")
+        XCTAssertEqual(sel?.isContinuation, false)
+    }
+
+    func testFollowsNearestEvenWhenAnotherHasMoreJoints() {
+        var tracker = PoseTracker(gate: 0.22)
+        // Lock onto a person at x=0.3.
+        _ = tracker.select(from: [pose(at: CGPoint(x: 0.3, y: 0.5), count: 5)])
+        // Next frame: the locked person drifted slightly to 0.33; a *richer*
+        // person is far away at 0.85. We must keep following the near one.
+        let near = pose(at: CGPoint(x: 0.33, y: 0.5), count: 4)
+        let farRich = pose(at: CGPoint(x: 0.85, y: 0.5), count: 8)
+        let sel = tracker.select(from: [farRich, near])
+        XCTAssertEqual(sel?.pose, near, "should follow the nearest, not the most prominent")
+        XCTAssertEqual(sel?.isContinuation, true)
+    }
+
+    func testReanchorsWhenNearestExceedsGate() {
+        var tracker = PoseTracker(gate: 0.22)
+        _ = tracker.select(from: [pose(at: CGPoint(x: 0.2, y: 0.2), count: 5)])
+        // The tracked person vanished; the only candidates are far away
+        // (> gate). Re-anchor to the most prominent of them.
+        let a = pose(at: CGPoint(x: 0.8, y: 0.8), count: 4)
+        let b = pose(at: CGPoint(x: 0.9, y: 0.9), count: 7)
+        let sel = tracker.select(from: [a, b])
+        XCTAssertEqual(sel?.pose, b)
+        XCTAssertEqual(sel?.isContinuation, false, "crossing the gate is a re-anchor")
+    }
+
+    func testResetReturnsToFirstLockBehaviour() {
+        var tracker = PoseTracker()
+        _ = tracker.select(from: [pose(at: CGPoint(x: 0.3, y: 0.3), count: 5)])
+        tracker.reset()
+        XCTAssertNil(tracker.lastCentroid)
+        // After reset, even a far candidate is accepted as a fresh lock.
+        let sel = tracker.select(from: [pose(at: CGPoint(x: 0.9, y: 0.9), count: 4)])
+        XCTAssertEqual(sel?.isContinuation, false)
+    }
+
+    func testTieOnJointCountBrokenByConfidence() {
+        var tracker = PoseTracker()
+        let lowConf = pose(at: CGPoint(x: 0.3, y: 0.5), count: 5, confidence: 0.4)
+        let highConf = pose(at: CGPoint(x: 0.7, y: 0.5), count: 5, confidence: 0.95)
+        let sel = tracker.select(from: [lowConf, highConf])
+        XCTAssertEqual(sel?.pose, highConf)
+    }
+
+    // MARK: - Centroid
+
+    func testCentroidIsAverageOfJoints() {
+        let p = DetectedPose(joints: [
+            DetectedJoint(name: .leftHip, normalizedPosition: CGPoint(x: 0.2, y: 0.4), confidence: 1),
+            DetectedJoint(name: .rightHip, normalizedPosition: CGPoint(x: 0.6, y: 0.8), confidence: 1),
+        ])
+        let c = PoseTracker.centroid(p)
+        XCTAssertEqual(c.x, 0.4, accuracy: 1e-9)
+        XCTAssertEqual(c.y, 0.6, accuracy: 1e-9)
+    }
+
+    func testCentroidOfEmptyPoseIsZero() {
+        XCTAssertEqual(PoseTracker.centroid(DetectedPose(joints: [])), .zero)
+    }
+}


### PR DESCRIPTION
Closes the "skeleton jumps around too much" report.

## Why it jumped

`PoseDetectionService` picked `observations.max(by: confidence)` **independently every frame**, with zero memory of who it picked last. With several dancers in shot (a social-dance clip, a mirror, a bystander), two people of similar confidence make it flip-flop frame to frame.

## Fix: continuity tracking

- **`detectPoses`** now returns *all* the people Vision finds (one `DetectedPose` per observation with joints above the floor), instead of choosing one statelessly. (A single unreadable observation no longer fails the whole frame, either.)
- **`PoseTracker`** (new, pure, tested) locks onto one person: each frame it picks the candidate whose centroid is nearest the one it chose last. Only when the nearest candidate is further than a `gate` — meaning the tracked dancer probably left the frame — does it re-anchor to the most prominent person (most joints, ties broken by mean confidence).
- **`PoseStreamCoordinator`** runs the tracker on each frame and resets it on start / stop / clip-swap. When the tracker re-anchors to a *different* body (`isContinuation == false`), it also resets the One-Euro smoother so the skeleton doesn't smear a path between two people.

A frame with no candidates leaves the lock untouched, so a brief dropout doesn't lose the person.

## What you'll see

Once the skeleton latches onto you (or whichever dancer is most clearly visible at the start), it should **stay** on that person even as others move through frame — only switching if your tracked dancer actually leaves.

## Tests

152 pass (was 144). 8 new `PoseTracker` tests: empty-frame keeps lock, first-lock picks most prominent, follows nearest over a richer-but-far candidate, re-anchors past the gate, reset behaviour, confidence tie-break, centroid math.

## Follow-up (if you still want manual control)

"Tap/long-press a person to pin them" — needs an inverse view→image coordinate mapping through the zoom/pan/mirror transforms. I left it out of this PR since continuity tracking addresses the actual "jumps around" pain; happy to add explicit pinning if the automatic lock isn't enough on your busier clips.
