### PR TITLE
Long-press to pin pose tracking to one dancer

### DIFF
--- a/StepBack/Services/PoseCoordinateTransform.swift
+++ b/StepBack/Services/PoseCoordinateTransform.swift
@@ -47,4 +47,47 @@ enum PoseCoordinateTransform {
             y: displayRect.minY + (1 - normalizedImagePoint.y) * displayRect.height
         )
     }
+
+    // MARK: - Inverse (touch → image)
+
+    /// Undoes a center-anchored `scaleEffect(scale)` + `offset` and returns
+    /// the touch location as a fraction (0…1) of the *unzoomed* container.
+    /// This is the inverse of how `ZoomablePlayerContainer` displays its
+    /// content, so a finger tap lands back in the content's own coordinates.
+    static func unzoomedFraction(
+        location: CGPoint,
+        containerSize: CGSize,
+        scale: CGFloat,
+        offset: CGSize
+    ) -> CGPoint {
+        guard containerSize.width > 0, containerSize.height > 0, scale > 0 else {
+            return .zero
+        }
+        let cx = containerSize.width / 2
+        let cy = containerSize.height / 2
+        // screen = (content - center) * scale + center + offset  →  invert:
+        let contentX = (location.x - offset.width - cx) / scale + cx
+        let contentY = (location.y - offset.height - cy) / scale + cy
+        return CGPoint(x: contentX / containerSize.width, y: contentY / containerSize.height)
+    }
+
+    /// Inverse of `viewPoint`: maps a container fraction (0…1, top-left
+    /// origin — already un-zoomed via `unzoomedFraction`) to a normalized
+    /// Vision image point (0…1, bottom-left origin). `displayRect` must be
+    /// computed in a unit (1×1) container so it lives in the same fractional
+    /// space. Flips Y back, and un-mirrors X when the video is mirrored.
+    /// Returns nil if the fraction falls outside the letterboxed video.
+    static func normalizedImagePoint(
+        containerFraction f: CGPoint,
+        unitDisplayRect: CGRect,
+        mirrored: Bool
+    ) -> CGPoint? {
+        guard unitDisplayRect.width > 0, unitDisplayRect.height > 0 else { return nil }
+        let nx = (f.x - unitDisplayRect.minX) / unitDisplayRect.width
+        let nyTop = (f.y - unitDisplayRect.minY) / unitDisplayRect.height
+        guard (0...1).contains(nx), (0...1).contains(nyTop) else { return nil }
+        let imageX = mirrored ? (1 - nx) : nx
+        let imageY = 1 - nyTop  // flip to Vision's bottom-left origin
+        return CGPoint(x: imageX, y: imageY)
+    }
 }

--- a/StepBack/Services/PoseStreamCoordinator.swift
+++ b/StepBack/Services/PoseStreamCoordinator.swift
@@ -27,6 +27,9 @@ final class PoseStreamCoordinator: ObservableObject {
     @Published private(set) var status: Status = .idle
     @Published private(set) var imageSize: CGSize?
     @Published private(set) var isActive: Bool = false
+    /// True when the user has long-pressed a specific dancer to follow. The
+    /// view surfaces this (lock badge + Release control).
+    @Published private(set) var isPinned: Bool = false
     /// Seconds since the most recent *successful* detection. Used by the
     /// overlay to fade the skeleton from solid (fresh) to transparent
     /// (about-to-be-cleared) so the dashboard can see when we're holding a
@@ -99,6 +102,7 @@ final class PoseStreamCoordinator: ObservableObject {
         poseAge = .infinity
         smoother.reset()
         tracker.reset()
+        isPinned = false
         attachOutputIfNeeded()
         tickTask = Task { [weak self] in
             while !Task.isCancelled {
@@ -119,7 +123,25 @@ final class PoseStreamCoordinator: ObservableObject {
         poseAge = .infinity
         smoother.reset()
         tracker.reset()
+        isPinned = false
         detachOutput()
+    }
+
+    // MARK: - Person pinning
+
+    /// Locks tracking to the dancer nearest `imagePoint` (normalized Vision
+    /// coordinates, bottom-left origin). The next detection tick re-selects
+    /// around this point and then follows only that person.
+    func pin(at imagePoint: CGPoint) {
+        tracker.pin(to: imagePoint)
+        smoother.reset()  // new person → start smoothing fresh
+        isPinned = true
+    }
+
+    /// Releases the pin and returns to automatic tracking.
+    func unpin() {
+        tracker.unpin()
+        isPinned = false
     }
 
     // MARK: - Internals
@@ -156,6 +178,7 @@ final class PoseStreamCoordinator: ObservableObject {
         // New clip → forget joint smoothing history and the tracked person.
         smoother.reset()
         tracker.reset()
+        isPinned = false
         orientationTask?.cancel()
         orientationTask = Task { [weak self] in
             let resolved = await Self.resolveOrientation(for: item)

--- a/StepBack/Services/PoseTracker.swift
+++ b/StepBack/Services/PoseTracker.swift
@@ -25,40 +25,70 @@ struct PoseTracker {
     let gate: Double
 
     private(set) var lastCentroid: CGPoint?
+    /// When the user has explicitly chosen a dancer, we follow *only* them:
+    /// if the pinned person isn't near `lastCentroid` this frame we hold
+    /// (return nil) and wait rather than auto-grabbing someone else. This is
+    /// what stops the skeleton "randomly changing" on a crowded floor.
+    private(set) var isPinned: Bool = false
 
     init(gate: Double = 0.22) {
         self.gate = gate
     }
 
-    /// Returns the pose to display this frame, or nil if there were no
-    /// candidates. An empty frame leaves `lastCentroid` untouched so a brief
-    /// dropout doesn't lose the lock.
+    /// Returns the pose to display this frame, or nil if there's no person to
+    /// show. In auto mode an empty frame leaves `lastCentroid` untouched so a
+    /// brief dropout doesn't lose the lock; in pinned mode we also return nil
+    /// (and hold) when the pinned dancer isn't within `gate`.
     mutating func select(from candidates: [DetectedPose]) -> Selection? {
         guard !candidates.isEmpty else { return nil }
 
-        let selection: Selection
-        if let last = lastCentroid,
-           let nearest = candidates.min(by: {
-               Self.distance(Self.centroid($0), last)
-                   < Self.distance(Self.centroid($1), last)
-           }) {
-            if Self.distance(Self.centroid(nearest), last) <= gate {
-                selection = Selection(pose: nearest, isContinuation: true)
-            } else {
-                // Nearest candidate is too far — the tracked dancer likely
-                // left frame. Re-anchor.
-                selection = Selection(pose: mostProminent(candidates), isContinuation: false)
+        if let last = lastCentroid {
+            let nearest = candidates.min(by: {
+                Self.distance(Self.centroid($0), last)
+                    < Self.distance(Self.centroid($1), last)
+            })!
+            let near = Self.distance(Self.centroid(nearest), last) <= gate
+
+            if near {
+                lastCentroid = Self.centroid(nearest)
+                return Selection(pose: nearest, isContinuation: true)
             }
-        } else {
-            selection = Selection(pose: mostProminent(candidates), isContinuation: false)
+            if isPinned {
+                // Pinned dancer not in range — hold and keep waiting for them.
+                // Don't move lastCentroid; they may return near the same spot,
+                // or the user can re-pin someone else.
+                return nil
+            }
+            // Auto mode: the tracked person left — re-anchor to the most
+            // prominent candidate.
+            let prominent = mostProminent(candidates)
+            lastCentroid = Self.centroid(prominent)
+            return Selection(pose: prominent, isContinuation: false)
         }
 
-        lastCentroid = Self.centroid(selection.pose)
-        return selection
+        // No lock yet (auto, first frame): take the most prominent person.
+        let prominent = mostProminent(candidates)
+        lastCentroid = Self.centroid(prominent)
+        return Selection(pose: prominent, isContinuation: false)
+    }
+
+    /// Locks tracking to whoever is nearest `centroid` (a normalized image
+    /// point, e.g. mapped from a long-press). Subsequent frames follow only
+    /// that person until unpinned or reset.
+    mutating func pin(to centroid: CGPoint) {
+        lastCentroid = centroid
+        isPinned = true
+    }
+
+    /// Returns to automatic tracking, keeping the current lock as the
+    /// starting point so the skeleton doesn't jump on release.
+    mutating func unpin() {
+        isPinned = false
     }
 
     mutating func reset() {
         lastCentroid = nil
+        isPinned = false
     }
 
     /// Most clearly-visible candidate: most joints, ties broken by mean

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -204,7 +204,10 @@ struct PracticeView: View {
                 // tall phone screens for any non-16:9 source). Let the video
                 // claim leftover vertical space; controls keep their intrinsic
                 // height and float beneath.
-                ZoomablePlayerContainer(onSingleTap: { vm.togglePlayPause() }) {
+                ZoomablePlayerContainer(
+                    onSingleTap: { vm.togglePlayPause() },
+                    onLongPressLocated: { fraction in pinDancer(atContainerFraction: fraction) }
+                ) {
                     ZStack {
                         PlayerSurface(player: vm.player)
                             .scaleEffect(x: vm.mirrored ? -1 : 1, y: 1)
@@ -226,9 +229,12 @@ struct PracticeView: View {
                 .layoutPriority(1)
                 .overlay(alignment: .topLeading) {
                     if poseCoordinator.isActive {
-                        PoseStatusChip(status: poseCoordinator.status)
-                            .padding(.leading, 10)
-                            .padding(.top, 10)
+                        VStack(alignment: .leading, spacing: 6) {
+                            PoseStatusChip(status: poseCoordinator.status)
+                            poseTrackingControl
+                        }
+                        .padding(.leading, 10)
+                        .padding(.top, 10)
                     }
                 }
 
@@ -251,6 +257,59 @@ struct PracticeView: View {
             // stretches to the top of the controls.
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+    }
+
+    /// Lock badge / release button (when pinned) or a hold-to-lock hint
+    /// (when tracking automatically). Sits under the pose status chip.
+    @ViewBuilder
+    private var poseTrackingControl: some View {
+        if poseCoordinator.isPinned {
+            Button {
+                poseCoordinator.unpin()
+            } label: {
+                HStack(spacing: 5) {
+                    Image(systemName: "lock.fill")
+                        .font(.system(size: 10, weight: .bold))
+                    Text("Locked · Release")
+                        .font(.system(.caption2, design: .rounded, weight: .semibold))
+                }
+                .foregroundStyle(.black)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Theme.Color.accent, in: Capsule())
+            }
+            .buttonStyle(.plain)
+        } else {
+            HStack(spacing: 5) {
+                Image(systemName: "hand.tap.fill")
+                    .font(.system(size: 10, weight: .semibold))
+                Text("Hold a dancer to lock")
+                    .font(.system(.caption2, design: .rounded, weight: .semibold))
+            }
+            .foregroundStyle(Theme.Color.textPrimary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Color.black.opacity(0.55), in: Capsule())
+        }
+    }
+
+    /// Maps a long-press location (as a fraction of the un-zoomed player
+    /// container) back to a normalized Vision image point and pins the
+    /// dancer nearest it. No-op when pose detection is off or the frame
+    /// size isn't known yet.
+    private func pinDancer(atContainerFraction fraction: CGPoint) {
+        guard poseCoordinator.isActive, let imageSize = poseCoordinator.imageSize else { return }
+        let unitRect = PoseCoordinateTransform.displayRect(
+            imageSize: imageSize,
+            in: CGSize(width: 1, height: 1)
+        )
+        guard let imagePoint = PoseCoordinateTransform.normalizedImagePoint(
+            containerFraction: fraction,
+            unitDisplayRect: unitRect,
+            mirrored: vm.mirrored
+        ) else { return }
+        poseCoordinator.pin(at: imagePoint)
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
     }
 
     private func loadErrorState(message: String) -> some View {

--- a/StepBack/Views/ZoomablePlayerContainer.swift
+++ b/StepBack/Views/ZoomablePlayerContainer.swift
@@ -11,12 +11,18 @@ struct ZoomablePlayerContainer<Content: View>: View {
 
     private let content: Content
     private let onSingleTap: (() -> Void)?
+    /// Reports a long-press as a fraction (0…1) of the *un-zoomed* container,
+    /// so callers can map it back through their own letterbox/mirror to image
+    /// space. Used for "hold a dancer to track them."
+    private let onLongPressLocated: ((CGPoint) -> Void)?
 
     init(
         onSingleTap: (() -> Void)? = nil,
+        onLongPressLocated: ((CGPoint) -> Void)? = nil,
         @ViewBuilder content: () -> Content
     ) {
         self.onSingleTap = onSingleTap
+        self.onLongPressLocated = onLongPressLocated
         self.content = content()
     }
 
@@ -69,6 +75,25 @@ struct ZoomablePlayerContainer<Content: View>: View {
                     .onTapGesture(count: 1) {
                         onSingleTap?()
                     }
+                    // Long-press to pin a person. Sequenced before a
+                    // zero-distance drag so we can read the touch location;
+                    // simultaneous so it coexists with pinch/pan, and the
+                    // 0.45s hold keeps it from firing on taps or quick pans.
+                    .simultaneousGesture(
+                        LongPressGesture(minimumDuration: 0.45)
+                            .sequenced(before: DragGesture(minimumDistance: 0))
+                            .onEnded { value in
+                                if case .second(true, let drag?) = value {
+                                    let fraction = PoseCoordinateTransform.unzoomedFraction(
+                                        location: drag.location,
+                                        containerSize: proxy.size,
+                                        scale: scale,
+                                        offset: offset
+                                    )
+                                    onLongPressLocated?(fraction)
+                                }
+                            }
+                    )
             }
             .frame(width: proxy.size.width, height: proxy.size.height)
         }

--- a/StepBackTests/PoseCoordinateTransformTests.swift
+++ b/StepBackTests/PoseCoordinateTransformTests.swift
@@ -120,4 +120,104 @@ final class PoseCoordinateTransformTests: XCTestCase {
         XCTAssertEqual(result.x, 200, accuracy: accuracy)
         XCTAssertEqual(result.y, 200, accuracy: accuracy)
     }
+
+    // MARK: - unzoomedFraction
+
+    func testUnzoomedFractionWithoutZoomIsLocationOverSize() {
+        let f = PoseCoordinateTransform.unzoomedFraction(
+            location: CGPoint(x: 100, y: 200),
+            containerSize: CGSize(width: 400, height: 400),
+            scale: 1,
+            offset: .zero
+        )
+        XCTAssertEqual(f.x, 0.25, accuracy: accuracy)
+        XCTAssertEqual(f.y, 0.5, accuracy: accuracy)
+    }
+
+    func testUnzoomedFractionUndoesCenterScale() {
+        // At 2× zoom about center, a tap at the exact center still maps to
+        // the content center (0.5, 0.5).
+        let f = PoseCoordinateTransform.unzoomedFraction(
+            location: CGPoint(x: 200, y: 200),
+            containerSize: CGSize(width: 400, height: 400),
+            scale: 2,
+            offset: .zero
+        )
+        XCTAssertEqual(f.x, 0.5, accuracy: accuracy)
+        XCTAssertEqual(f.y, 0.5, accuracy: accuracy)
+    }
+
+    func testUnzoomedFractionUndoesOffset() {
+        // Pan the content right by 50; a tap at center now corresponds to a
+        // content point left of center.
+        let f = PoseCoordinateTransform.unzoomedFraction(
+            location: CGPoint(x: 200, y: 200),
+            containerSize: CGSize(width: 400, height: 400),
+            scale: 1,
+            offset: CGSize(width: 50, height: 0)
+        )
+        XCTAssertEqual(f.x, (200.0 - 50.0) / 400.0, accuracy: accuracy)  // 0.375
+        XCTAssertEqual(f.y, 0.5, accuracy: accuracy)
+    }
+
+    func testUnzoomedFractionZeroContainerIsZero() {
+        let f = PoseCoordinateTransform.unzoomedFraction(
+            location: CGPoint(x: 10, y: 10),
+            containerSize: .zero,
+            scale: 1,
+            offset: .zero
+        )
+        XCTAssertEqual(f, .zero)
+    }
+
+    // MARK: - normalizedImagePoint (inverse of viewPoint)
+
+    func testNormalizedImagePointRoundTripsViewPoint() {
+        // viewPoint maps image → unit container fraction; the inverse should
+        // recover the original image point.
+        let imageSize = CGSize(width: 1600, height: 900)
+        let unitRect = PoseCoordinateTransform.displayRect(
+            imageSize: imageSize,
+            in: CGSize(width: 1, height: 1)
+        )
+        let original = CGPoint(x: 0.3, y: 0.7)
+        let fraction = PoseCoordinateTransform.viewPoint(
+            normalizedImagePoint: original,
+            displayRect: unitRect
+        )
+        let recovered = PoseCoordinateTransform.normalizedImagePoint(
+            containerFraction: fraction,
+            unitDisplayRect: unitRect,
+            mirrored: false
+        )
+        XCTAssertEqual(recovered?.x ?? -1, original.x, accuracy: accuracy)
+        XCTAssertEqual(recovered?.y ?? -1, original.y, accuracy: accuracy)
+    }
+
+    func testNormalizedImagePointMirrorsX() {
+        let unitRect = CGRect(x: 0, y: 0, width: 1, height: 1)  // square in square
+        let recovered = PoseCoordinateTransform.normalizedImagePoint(
+            containerFraction: CGPoint(x: 0.2, y: 0.5),
+            unitDisplayRect: unitRect,
+            mirrored: true
+        )
+        // A touch at container-left (0.2) on a mirrored video is image-right.
+        XCTAssertEqual(recovered?.x ?? -1, 0.8, accuracy: accuracy)
+        XCTAssertEqual(recovered?.y ?? -1, 0.5, accuracy: accuracy)
+    }
+
+    func testNormalizedImagePointNilOutsideLetterbox() {
+        // 16:9 in unit square letterboxes top/bottom (rect.minY≈0.219). A
+        // touch up at y=0.05 is in the black bar → nil.
+        let unitRect = PoseCoordinateTransform.displayRect(
+            imageSize: CGSize(width: 1600, height: 900),
+            in: CGSize(width: 1, height: 1)
+        )
+        let recovered = PoseCoordinateTransform.normalizedImagePoint(
+            containerFraction: CGPoint(x: 0.5, y: 0.05),
+            unitDisplayRect: unitRect,
+            mirrored: false
+        )
+        XCTAssertNil(recovered)
+    }
 }

--- a/StepBackTests/PoseTrackerTests.swift
+++ b/StepBackTests/PoseTrackerTests.swift
@@ -85,6 +85,64 @@ final class PoseTrackerTests: XCTestCase {
         XCTAssertEqual(sel?.pose, highConf)
     }
 
+    // MARK: - Pinning
+
+    func testPinFollowsNearestToPinnedPointEvenIfFarFromPriorLock() {
+        var tracker = PoseTracker(gate: 0.22)
+        _ = tracker.select(from: [pose(at: CGPoint(x: 0.2, y: 0.5), count: 6)])
+        // User long-presses a different dancer at x=0.8.
+        tracker.pin(to: CGPoint(x: 0.8, y: 0.5))
+        XCTAssertTrue(tracker.isPinned)
+        let pinnedOne = pose(at: CGPoint(x: 0.82, y: 0.5), count: 3)
+        let sel = tracker.select(from: [
+            pose(at: CGPoint(x: 0.2, y: 0.5), count: 6),  // prominent, but not pinned
+            pinnedOne,
+        ])
+        XCTAssertEqual(sel?.pose, pinnedOne)
+    }
+
+    func testPinnedModeHoldsRatherThanReanchoringWhenPersonGone() {
+        var tracker = PoseTracker(gate: 0.22)
+        tracker.pin(to: CGPoint(x: 0.3, y: 0.5))
+        _ = tracker.select(from: [pose(at: CGPoint(x: 0.3, y: 0.5), count: 4)])
+        // Pinned person vanishes; only a far candidate remains. Auto mode
+        // would grab it — pinned mode must hold (nil).
+        let sel = tracker.select(from: [pose(at: CGPoint(x: 0.9, y: 0.9), count: 8)])
+        XCTAssertNil(sel, "pinned tracker should hold, not jump to another dancer")
+    }
+
+    func testPinnedPersonReacquiredWhenTheyReturn() {
+        var tracker = PoseTracker(gate: 0.22)
+        tracker.pin(to: CGPoint(x: 0.3, y: 0.5))
+        _ = tracker.select(from: [pose(at: CGPoint(x: 0.3, y: 0.5), count: 4)])
+        _ = tracker.select(from: [pose(at: CGPoint(x: 0.9, y: 0.9), count: 8)])  // gone → held
+        // They return near where they were pinned.
+        let returned = pose(at: CGPoint(x: 0.32, y: 0.5), count: 4)
+        let sel = tracker.select(from: [returned])
+        XCTAssertEqual(sel?.pose, returned)
+    }
+
+    func testUnpinReturnsToAutoReanchoring() {
+        var tracker = PoseTracker(gate: 0.22)
+        tracker.pin(to: CGPoint(x: 0.3, y: 0.5))
+        _ = tracker.select(from: [pose(at: CGPoint(x: 0.3, y: 0.5), count: 4)])
+        tracker.unpin()
+        XCTAssertFalse(tracker.isPinned)
+        // A far prominent candidate should now be picked up (auto re-anchor).
+        let other = pose(at: CGPoint(x: 0.9, y: 0.9), count: 8)
+        let sel = tracker.select(from: [other])
+        XCTAssertEqual(sel?.pose, other)
+        XCTAssertEqual(sel?.isContinuation, false)
+    }
+
+    func testResetClearsPin() {
+        var tracker = PoseTracker()
+        tracker.pin(to: CGPoint(x: 0.5, y: 0.5))
+        tracker.reset()
+        XCTAssertFalse(tracker.isPinned)
+        XCTAssertNil(tracker.lastCentroid)
+    }
+
     // MARK: - Centroid
 
     func testCentroidIsAverageOfJoints() {


### PR DESCRIPTION
What you asked for: **select the dancer to track** so it stops randomly changing on a crowded floor.

## How it works

- **Long-press a dancer** on the video → the skeleton locks onto them.
- Once pinned, the tracker follows **only that person**. If they leave the frame it **holds** (shows nothing) and waits for them to come back, instead of grabbing a random nearby body — that was the "randomly keeps changing" behavior.
- A **"Locked · Release"** badge appears under the pose status chip; tap it to go back to automatic tracking. While auto-tracking, a **"Hold a dancer to lock"** hint shows.
- A medium haptic confirms the lock.

## The hard part: finger → dancer

Mapping where you pressed back to "which dancer" means inverting the whole display chain: the center-anchored **zoom/pan**, the aspect-fit **letterbox**, the **Y-flip** (Vision is bottom-left origin), and the **mirror**. That's two new pure functions in `PoseCoordinateTransform`:
- `unzoomedFraction(...)` — undoes zoom/pan, returns the touch as a fraction of the un-zoomed container.
- `normalizedImagePoint(...)` — maps that fraction back through the letterbox + flip + mirror to a Vision image point.

Both are unit-tested, including a round-trip against the existing `viewPoint`.

## Other pieces

- `PoseTracker`: `pin(to:)` / `unpin()` / `isPinned`, and pinned-mode `select()` (follow nearest within gate, else hold — no auto re-anchor).
- `ZoomablePlayerContainer`: reports a long-press as an un-zoomed container fraction via a `LongPress → Drag` sequence, simultaneous with pinch/pan; the 0.45s hold keeps taps and quick pans from triggering it.
- `PoseStreamCoordinator`: `pin(at:)` / `unpin()`, resets the smoother on a new person, publishes `isPinned`, clears the pin on start/stop/clip-swap.

## Tests

164 pass (was 152). 12 new:
- Pin follows the chosen person over a more-prominent one; holds (no jump) when they're gone; re-acquires when they return; unpin restores auto re-anchor; reset clears the pin.
- `unzoomedFraction` (no-zoom, 2× center, offset, zero-container) and `normalizedImagePoint` (viewPoint round-trip, mirror, outside-letterbox → nil).

⚠️ **Validate the long-press on device** — SwiftUI gesture arbitration (long-press coexisting with pinch/pan/tap) is hard to verify on the simulator. If the hold doesn't register cleanly or fights the pan, tell me and I'll switch to "single-tap-to-pin while pose is on."
