### PR TITLE
Sticky dancer lock: prediction + ambiguity hold + debug view

### DIFF
--- a/StepBack/Services/PoseStreamCoordinator.swift
+++ b/StepBack/Services/PoseStreamCoordinator.swift
@@ -30,6 +30,10 @@ final class PoseStreamCoordinator: ObservableObject {
     /// True when the user has long-pressed a specific dancer to follow. The
     /// view surfaces this (lock badge + Release control).
     @Published private(set) var isPinned: Bool = false
+    /// Every person detected in the latest processed frame (not just the
+    /// tracked one). Published for the optional debug overlay so the user
+    /// can see which bodies the tracker was choosing between.
+    @Published private(set) var candidates: [DetectedPose] = []
     /// Seconds since the most recent *successful* detection. Used by the
     /// overlay to fade the skeleton from solid (fresh) to transparent
     /// (about-to-be-cleared) so the dashboard can see when we're holding a
@@ -103,6 +107,7 @@ final class PoseStreamCoordinator: ObservableObject {
         smoother.reset()
         tracker.reset()
         isPinned = false
+        candidates = []
         attachOutputIfNeeded()
         tickTask = Task { [weak self] in
             while !Task.isCancelled {
@@ -124,6 +129,7 @@ final class PoseStreamCoordinator: ObservableObject {
         smoother.reset()
         tracker.reset()
         isPinned = false
+        candidates = []
         detachOutput()
     }
 
@@ -252,6 +258,8 @@ final class PoseStreamCoordinator: ObservableObject {
         let result = await detect(pixelBuffer: pixelBuffer, orientation: orientation)
         switch result {
         case .success(let candidates):
+            // Publish all candidates for the debug overlay before selection.
+            self.candidates = candidates
             // Lock onto one person across frames. Returns nil only when the
             // frame had no candidates at all.
             if let selection = tracker.select(from: candidates) {

--- a/StepBack/Services/PoseTracker.swift
+++ b/StepBack/Services/PoseTracker.swift
@@ -21,55 +21,82 @@ struct PoseTracker {
     }
 
     /// Max distance (normalized image units) between this frame's chosen
-    /// centroid and the previous one for them to count as the same person.
+    /// centroid and the *predicted* one for them to count as the same person.
     let gate: Double
+    /// If the second-nearest candidate is within this of the nearest (both
+    /// plausibly "you"), a pinned tracker holds instead of guessing — this
+    /// is what stops it hopping to a partner passing close.
+    let ambiguityMargin: Double
+    /// How much of the last frame's motion to project forward when
+    /// predicting where the tracked dancer is now. Matching against the
+    /// prediction (not the stale last position) stops a stationary passer-by
+    /// near the old spot from stealing a fast-moving lock.
+    let velocityDamping: Double
 
     private(set) var lastCentroid: CGPoint?
+    private(set) var lastVelocity: CGVector = .zero
     /// When the user has explicitly chosen a dancer, we follow *only* them:
-    /// if the pinned person isn't near `lastCentroid` this frame we hold
+    /// if the pinned person isn't near the prediction this frame we hold
     /// (return nil) and wait rather than auto-grabbing someone else. This is
     /// what stops the skeleton "randomly changing" on a crowded floor.
     private(set) var isPinned: Bool = false
 
-    init(gate: Double = 0.22) {
+    init(
+        gate: Double = 0.22,
+        ambiguityMargin: Double = 0.05,
+        velocityDamping: Double = 0.6
+    ) {
         self.gate = gate
+        self.ambiguityMargin = ambiguityMargin
+        self.velocityDamping = velocityDamping
+    }
+
+    /// Where we expect the tracked dancer to be this frame: last position
+    /// plus a damped projection of the last motion.
+    var predictedCentroid: CGPoint? {
+        guard let last = lastCentroid else { return nil }
+        return CGPoint(
+            x: last.x + velocityDamping * lastVelocity.dx,
+            y: last.y + velocityDamping * lastVelocity.dy
+        )
     }
 
     /// Returns the pose to display this frame, or nil if there's no person to
-    /// show. In auto mode an empty frame leaves `lastCentroid` untouched so a
-    /// brief dropout doesn't lose the lock; in pinned mode we also return nil
-    /// (and hold) when the pinned dancer isn't within `gate`.
+    /// show. In auto mode an empty frame leaves the lock untouched so a brief
+    /// dropout doesn't lose it; in pinned mode we also return nil (and hold)
+    /// when the pinned dancer isn't confidently identifiable this frame.
     mutating func select(from candidates: [DetectedPose]) -> Selection? {
         guard !candidates.isEmpty else { return nil }
 
-        if let last = lastCentroid {
-            let nearest = candidates.min(by: {
-                Self.distance(Self.centroid($0), last)
-                    < Self.distance(Self.centroid($1), last)
-            })!
-            let near = Self.distance(Self.centroid(nearest), last) <= gate
+        guard let predicted = predictedCentroid else {
+            // No lock yet (auto, first frame): take the most prominent person.
+            return adopt(mostProminent(candidates), isContinuation: false)
+        }
 
-            if near {
-                lastCentroid = Self.centroid(nearest)
-                return Selection(pose: nearest, isContinuation: true)
-            }
+        let ranked = candidates
+            .map { ($0, Self.distance(Self.centroid($0), predicted)) }
+            .sorted { $0.1 < $1.1 }
+        let (best, bestDist) = ranked[0]
+
+        if bestDist > gate {
             if isPinned {
-                // Pinned dancer not in range — hold and keep waiting for them.
-                // Don't move lastCentroid; they may return near the same spot,
-                // or the user can re-pin someone else.
+                // Pinned dancer not where we expect — hold and wait. Don't
+                // move the lock; they may return near the same spot.
                 return nil
             }
             // Auto mode: the tracked person left — re-anchor to the most
             // prominent candidate.
-            let prominent = mostProminent(candidates)
-            lastCentroid = Self.centroid(prominent)
-            return Selection(pose: prominent, isContinuation: false)
+            return adopt(mostProminent(candidates), isContinuation: false)
         }
 
-        // No lock yet (auto, first frame): take the most prominent person.
-        let prominent = mostProminent(candidates)
-        lastCentroid = Self.centroid(prominent)
-        return Selection(pose: prominent, isContinuation: false)
+        // A rival is almost as close as the best match. When pinned, refuse
+        // to guess — hold so we don't hop to whoever's passing. (Auto mode
+        // doesn't hold; momentary wrong picks there self-correct next frame.)
+        if isPinned, ranked.count >= 2, ranked[1].1 - bestDist < ambiguityMargin {
+            return nil
+        }
+
+        return adopt(best, isContinuation: true)
     }
 
     /// Locks tracking to whoever is nearest `centroid` (a normalized image
@@ -77,6 +104,7 @@ struct PoseTracker {
     /// that person until unpinned or reset.
     mutating func pin(to centroid: CGPoint) {
         lastCentroid = centroid
+        lastVelocity = .zero
         isPinned = true
     }
 
@@ -88,7 +116,21 @@ struct PoseTracker {
 
     mutating func reset() {
         lastCentroid = nil
+        lastVelocity = .zero
         isPinned = false
+    }
+
+    /// Commits to `pose`, updating the lock position and the velocity
+    /// estimate (the step from the previous lock to this one).
+    private mutating func adopt(_ pose: DetectedPose, isContinuation: Bool) -> Selection {
+        let c = Self.centroid(pose)
+        if isContinuation, let last = lastCentroid {
+            lastVelocity = CGVector(dx: c.x - last.x, dy: c.y - last.y)
+        } else {
+            lastVelocity = .zero
+        }
+        lastCentroid = c
+        return Selection(pose: pose, isContinuation: isContinuation)
     }
 
     /// Most clearly-visible candidate: most joints, ties broken by mean

--- a/StepBack/Views/PoseOverlay.swift
+++ b/StepBack/Views/PoseOverlay.swift
@@ -32,6 +32,10 @@ struct PoseOverlay: View {
     /// Seconds since the last successful detection. The coordinator caps
     /// this at `staleAfter` (0.5s) before clearing `pose`.
     var poseAge: TimeInterval = 0
+    /// All detected people this frame. When non-empty, a debug layer rings
+    /// each one's centroid so the user can see which bodies the tracker was
+    /// choosing between (and which it locked onto). Empty = debug off.
+    var debugCandidates: [DetectedPose] = []
 
     /// Fade ramp parameters. Below `fadeStart` the skeleton is fully solid
     /// — every fresh detection looks the same. Past it we ramp linearly to
@@ -42,17 +46,26 @@ struct PoseOverlay: View {
 
     var body: some View {
         GeometryReader { geo in
-            if let pose, let imageSize {
+            if let imageSize {
                 let rect = PoseCoordinateTransform.displayRect(
                     imageSize: imageSize,
                     in: geo.size
                 )
-                Canvas { context, _ in
-                    drawBones(pose: pose, displayRect: rect, context: context)
-                    drawJoints(pose: pose, displayRect: rect, context: context)
-                    drawCenterOfMass(pose: pose, displayRect: rect, context: context)
+                ZStack {
+                    if let pose {
+                        Canvas { context, _ in
+                            drawBones(pose: pose, displayRect: rect, context: context)
+                            drawJoints(pose: pose, displayRect: rect, context: context)
+                            drawCenterOfMass(pose: pose, displayRect: rect, context: context)
+                        }
+                        .opacity(freshnessOpacity)
+                    }
+                    if !debugCandidates.isEmpty {
+                        Canvas { context, _ in
+                            drawDebugCandidates(displayRect: rect, context: context)
+                        }
+                    }
                 }
-                .opacity(freshnessOpacity)
             }
         }
         .allowsHitTesting(false)
@@ -211,6 +224,36 @@ struct PoseOverlay: View {
             tick.move(to: CGPoint(x: ankle.x - 10, y: ankle.y))
             tick.addLine(to: CGPoint(x: ankle.x + 10, y: ankle.y))
             context.stroke(tick, with: .color(tint.opacity(0.8)), lineWidth: 2)
+        }
+    }
+
+    /// Debug layer: rings every detected person's centroid and labels it
+    /// with its joint count, so a screen recording shows which bodies the
+    /// tracker chose between. The currently-tracked person also has the full
+    /// coloured skeleton drawn over their ring.
+    private func drawDebugCandidates(
+        displayRect: CGRect,
+        context: GraphicsContext
+    ) {
+        for (index, candidate) in debugCandidates.enumerated() {
+            let c = PoseTracker.centroid(candidate)
+            let p = PoseCoordinateTransform.viewPoint(
+                normalizedImagePoint: c,
+                displayRect: displayRect
+            )
+            let r: CGFloat = 14
+            let ring = CGRect(x: p.x - r, y: p.y - r, width: r * 2, height: r * 2)
+            context.stroke(
+                Path(ellipseIn: ring),
+                with: .color(.cyan.opacity(0.9)),
+                lineWidth: 2
+            )
+            context.draw(
+                Text("\(index): \(candidate.joints.count)j")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(.cyan),
+                at: CGPoint(x: p.x, y: p.y - r - 8)
+            )
         }
     }
 

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -20,6 +20,9 @@ struct PracticeView: View {
     /// Single-tap on the video remains wired to play/pause so pausing
     /// doesn't require bringing controls back first.
     @State private var controlsHidden: Bool = false
+    /// Debug: ring every detected person so hops are diagnosable from a
+    /// screen recording.
+    @State private var poseDebug: Bool = false
     @StateObject private var poseCoordinator: PoseStreamCoordinator
 
     init(clip: DanceClip) {
@@ -218,7 +221,8 @@ struct PracticeView: View {
                             PoseOverlay(
                                 pose: poseCoordinator.pose,
                                 imageSize: poseCoordinator.imageSize,
-                                poseAge: poseCoordinator.poseAge
+                                poseAge: poseCoordinator.poseAge,
+                                debugCandidates: poseDebug ? poseCoordinator.candidates : []
                             )
                             .scaleEffect(x: vm.mirrored ? -1 : 1, y: 1)
                         }
@@ -232,6 +236,7 @@ struct PracticeView: View {
                         VStack(alignment: .leading, spacing: 6) {
                             PoseStatusChip(status: poseCoordinator.status)
                             poseTrackingControl
+                            poseDebugToggle
                         }
                         .padding(.leading, 10)
                         .padding(.top, 10)
@@ -291,6 +296,26 @@ struct PracticeView: View {
             .padding(.vertical, 4)
             .background(Color.black.opacity(0.55), in: Capsule())
         }
+    }
+
+    /// Small debug toggle: rings every detected person so a screen recording
+    /// shows which body the tracker locked onto and which it skipped.
+    private var poseDebugToggle: some View {
+        Button {
+            poseDebug.toggle()
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: poseDebug ? "ladybug.fill" : "ladybug")
+                    .font(.system(size: 10, weight: .semibold))
+                Text(poseDebug ? "Debug on" : "Debug")
+                    .font(.system(.caption2, design: .rounded, weight: .semibold))
+            }
+            .foregroundStyle(poseDebug ? .cyan : Theme.Color.textSecondary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Color.black.opacity(0.55), in: Capsule())
+        }
+        .buttonStyle(.plain)
     }
 
     /// Maps a long-press location (as a fraction of the un-zoomed player

--- a/StepBackTests/PoseTrackerTests.swift
+++ b/StepBackTests/PoseTrackerTests.swift
@@ -143,6 +143,52 @@ final class PoseTrackerTests: XCTestCase {
         XCTAssertNil(tracker.lastCentroid)
     }
 
+    // MARK: - Prediction & ambiguity
+
+    func testPredictionFollowsMovingDancerOverStationaryRival() {
+        var tracker = PoseTracker(gate: 0.22, ambiguityMargin: 0.05, velocityDamping: 0.6)
+        // Build up a consistent rightward motion: 0.30 → 0.40.
+        _ = tracker.select(from: [pose(at: CGPoint(x: 0.30, y: 0.5), count: 5)])
+        _ = tracker.select(from: [pose(at: CGPoint(x: 0.40, y: 0.5), count: 5)])
+        // Velocity is +0.10. Predicted ≈ 0.40 + 0.6*0.10 = 0.46.
+        // Now the dancer is at 0.50; a stationary rival sits at 0.36 (near the
+        // OLD position). Naive nearest-to-last (0.40) would grab 0.36; the
+        // prediction should keep us on 0.50.
+        let dancer = pose(at: CGPoint(x: 0.50, y: 0.5), count: 5)
+        let rival = pose(at: CGPoint(x: 0.36, y: 0.5), count: 5)
+        let sel = tracker.select(from: [rival, dancer])
+        XCTAssertEqual(sel?.pose, dancer, "prediction should keep the fast-moving dancer")
+    }
+
+    func testPinnedHoldsWhenTwoCandidatesAreEquallyClose() {
+        var tracker = PoseTracker(gate: 0.22, ambiguityMargin: 0.05)
+        tracker.pin(to: CGPoint(x: 0.50, y: 0.5))
+        // Two candidates straddle the pinned point at equal distance (0.03)
+        // — a partner overlapping during a pass. Refuse to guess → hold.
+        let a = pose(at: CGPoint(x: 0.47, y: 0.5), count: 5)
+        let b = pose(at: CGPoint(x: 0.53, y: 0.5), count: 5)
+        XCTAssertNil(tracker.select(from: [a, b]), "ambiguous frame should hold, not hop")
+    }
+
+    func testPinnedAcceptsWhenOneCandidateIsClearlyClosest() {
+        var tracker = PoseTracker(gate: 0.22, ambiguityMargin: 0.05)
+        tracker.pin(to: CGPoint(x: 0.50, y: 0.5))
+        // One right on the pin, the rival well outside the margin.
+        let onPin = pose(at: CGPoint(x: 0.50, y: 0.5), count: 5)
+        let rival = pose(at: CGPoint(x: 0.70, y: 0.5), count: 5)
+        let sel = tracker.select(from: [rival, onPin])
+        XCTAssertEqual(sel?.pose, onPin)
+    }
+
+    func testPinResetsVelocity() {
+        var tracker = PoseTracker()
+        _ = tracker.select(from: [pose(at: CGPoint(x: 0.2, y: 0.5))])
+        _ = tracker.select(from: [pose(at: CGPoint(x: 0.4, y: 0.5))])  // velocity +0.2
+        tracker.pin(to: CGPoint(x: 0.8, y: 0.5))
+        XCTAssertEqual(tracker.lastVelocity.dx, 0, accuracy: 1e-9)
+        XCTAssertEqual(tracker.lastVelocity.dy, 0, accuracy: 1e-9)
+    }
+
     // MARK: - Centroid
 
     func testCentroidIsAverageOfJoints() {


### PR DESCRIPTION
Addresses "it still sometimes hops to other people" — plus a debug view so you can give me precise feedback on whatever's left.

## Why it hopped

Matching was pure proximity to the dancer's *last* position. Two failure modes:
1. A passer-by sits near your old spot → for a frame they're "nearest" → lock hops.
2. You move fast → a stationary person near your old position is nearest → lock hops.

## Two fixes (pure logic, tested)

- **Motion prediction.** The tracker now estimates your velocity and matches candidates against where you're *predicted* to be (`last + damping·velocity`), not where you were. A stationary passer-by near the old spot stops stealing a moving lock.
- **Ambiguity hold.** When pinned and two bodies are *both* plausibly you (overlapping during a pass — the second-nearest is within `ambiguityMargin` of the nearest), the tracker **refuses to guess and holds**. The existing 0.5s stale-hold keeps your last skeleton on screen during the brief overlap, then re-acquires *you* once you separate — instead of confidently locking the wrong person.

Auto (un-pinned) mode keeps its re-anchor behaviour; momentary wrong picks there self-correct next frame.

## Debug view (so you can show me the rest)

- New **"Debug"** toggle under the pose status chip (ladybug icon).
- When on, **every detected person gets a cyan ring** labelled with their joint count; the tracked person also shows the full skeleton. So a screen recording now shows exactly which bodies were on screen and which one the tracker grabbed.

**To report a hop:** turn Debug on, screen-record a hop, and note the trigger (partner crossing front/behind, you moving fast, you turning away, the other person closer/further from camera). Drop it in a GitHub issue or here. With the rings visible I can see whether it was a proximity collision, a prediction miss, or a depth/size case — and pick the right next lever (e.g. matching on body size, or torso-color re-ID).

## Tests

168 pass (was 164). 4 new: prediction beats a stationary rival; an ambiguous frame holds; a clearly-closest candidate is still accepted; pin resets velocity.

⚠️ Tuning note: `gate` (0.22), `ambiguityMargin` (0.05), and `velocityDamping` (0.6) are first-guess values I couldn't calibrate on real footage. The debug recordings will tell us if they need adjusting.
