### PR TITLE
Guard PhotosService against continuation double-resume (#53)

### DIFF
--- a/StepBack/Services/PhotosService.swift
+++ b/StepBack/Services/PhotosService.swift
@@ -1,8 +1,26 @@
 import AVFoundation
 import CoreMedia
 import Foundation
+import os
 import Photos
 import UIKit
+
+/// One-shot gate: runs the supplied closure only on its first invocation,
+/// no-ops thereafter, safely across threads. Used to resume a
+/// `CheckedContinuation` exactly once when the underlying callback can fire
+/// more than once. Resuming a continuation twice is a hard crash.
+final class ResumeOnce: @unchecked Sendable {
+    private let claimed = OSAllocatedUnfairLock(initialState: false)
+
+    func run(_ body: () -> Void) {
+        let isFirst = claimed.withLock { alreadyClaimed -> Bool in
+            if alreadyClaimed { return false }
+            alreadyClaimed = true
+            return true
+        }
+        if isFirst { body() }
+    }
+}
 
 enum PhotosError: Error, Equatable {
     case authorizationDenied
@@ -61,17 +79,22 @@ final class PhotosService: PhotosServicing, @unchecked Sendable {
         options.isNetworkAccessAllowed = true
         options.version = .current
 
+        // `requestAVAsset` can invoke its result handler more than once
+        // (progressive / iCloud delivery, or a cancel followed by a result).
+        // A CheckedContinuation must resume exactly once or it traps, so gate
+        // every path through a one-shot guard.
+        let resume = ResumeOnce()
         return try await withCheckedThrowingContinuation { continuation in
             imageManager.requestAVAsset(forVideo: phAsset, options: options) { avAsset, _, info in
                 if let error = info?[PHImageErrorKey] as? Error {
-                    continuation.resume(throwing: error)
+                    resume.run { continuation.resume(throwing: error) }
                     return
                 }
                 guard let urlAsset = avAsset as? AVURLAsset else {
-                    continuation.resume(throwing: PhotosError.notAVURLAsset)
+                    resume.run { continuation.resume(throwing: PhotosError.notAVURLAsset) }
                     return
                 }
-                continuation.resume(returning: urlAsset)
+                resume.run { continuation.resume(returning: urlAsset) }
             }
         }
     }

--- a/StepBackTests/PhotosServiceTests.swift
+++ b/StepBackTests/PhotosServiceTests.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import os
 import Photos
 @testable import StepBack
 import XCTest
@@ -32,5 +33,28 @@ final class PhotosServiceTests: XCTestCase {
             .notDetermined, .restricted, .denied, .authorized, .limited
         ]
         XCTAssertTrue(valid.contains(status))
+    }
+
+    // MARK: - ResumeOnce (the #53 double-resume guard)
+
+    func testResumeOnceRunsBodyExactlyOnce() {
+        let guardOnce = ResumeOnce()
+        var count = 0
+        guardOnce.run { count += 1 }
+        guardOnce.run { count += 1 }
+        guardOnce.run { count += 1 }
+        XCTAssertEqual(count, 1, "only the first call should run")
+    }
+
+    func testResumeOnceIsThreadSafeUnderConcurrency() {
+        // Hammer it from many threads at once; exactly one body must run —
+        // this is the property that prevents the continuation double-resume.
+        let guardOnce = ResumeOnce()
+        let counter = OSAllocatedUnfairLock(initialState: 0)
+        let iterations = 1_000
+        DispatchQueue.concurrentPerform(iterations: iterations) { _ in
+            guardOnce.run { counter.withLock { $0 += 1 } }
+        }
+        XCTAssertEqual(counter.withLock { $0 }, 1, "exactly one body across \(iterations) racing calls")
     }
 }


### PR DESCRIPTION
Closes #53. High-tier review fix #2 — the only crash risk found.

## The bug

`PHImageManager.requestAVAsset(forVideo:)` can invoke its result handler **more than once** (progressive / iCloud delivery, or a cancel followed by a result). Every path in our handler called `continuation.resume(...)`, so a second invocation that reached another `resume` traps the whole process with **"SWIFT TASK CONTINUATION MISUSE"**. That's the concrete crash behind issue #53.

## Fix

- **`ResumeOnce`** — a thread-safe one-shot gate (`OSAllocatedUnfairLock`) that runs its closure only on the first call, no-ops after.
- `resolveAVAsset` routes all three resume paths (error / not-a-URL-asset / success) through it, so the continuation resumes exactly once no matter how many times the handler fires. Semantics are otherwise unchanged — first definitive outcome wins.

## Tests

170 pass (was 168). 2 new:
- `ResumeOnce` runs its body exactly once across repeated calls.
- It runs exactly once under 1000-way `concurrentPerform` — the property that actually prevents the double-resume.

(A full `resolveAVAsset` integration test still needs a PHImageManager mock / device run, as the existing test file notes — but the guard logic itself is now covered.)
