### PR TITLE
Non-destructive, re-editable trim

### DIFF
--- a/StepBack.xcodeproj/project.pbxproj
+++ b/StepBack.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		2B90619AE0B5262B774DEAC1 /* PracticeControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35987D9825155E131A40950 /* PracticeControls.swift */; };
 		3D990657ED52C04DBB04687A /* NowPlayingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46242480BEBB0CDD9B45F158 /* NowPlayingController.swift */; };
 		4181110140BD581DBFB0A380 /* StepTimingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3B8C1BB7ACE2D1C13C7200 /* StepTimingTests.swift */; };
+		49AACC760BDA11B944F52A54 /* TrimStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13FAD0D9852D962D4419DC8F /* TrimStorageTests.swift */; };
 		52562CC7EBC717613965ADAB /* PoseStreamCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5844567C104B87D338953E6 /* PoseStreamCoordinator.swift */; };
 		527B9B596B00D2C774173ECA /* PracticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35AE6C8D6564306E1B0ADA20 /* PracticeView.swift */; };
 		5F405BD1B2F2EB7F30970683 /* LibraryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4B3FD6B0A004C787FC243B /* LibraryFormatterTests.swift */; };
@@ -80,6 +81,7 @@
 		078CB839E392E788201DD665 /* BeatGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeatGrid.swift; sourceTree = "<group>"; };
 		08505D0FA11E6637197AF8EC /* PoseOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoseOverlay.swift; sourceTree = "<group>"; };
 		0C54B956DF5DE01C00D95680 /* AutoTagServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoTagServiceTests.swift; sourceTree = "<group>"; };
+		13FAD0D9852D962D4419DC8F /* TrimStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimStorageTests.swift; sourceTree = "<group>"; };
 		16E676751B59ED083837CE39 /* SpeedFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedFormatterTests.swift; sourceTree = "<group>"; };
 		284F5B49794793B83D590351 /* PoseOrientationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoseOrientationTests.swift; sourceTree = "<group>"; };
 		2D07843122196F5F0DA539D1 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
@@ -193,6 +195,7 @@
 				DB3B8C1BB7ACE2D1C13C7200 /* StepTimingTests.swift */,
 				B7C112AEA59633E85CF8267D /* ThemeTests.swift */,
 				EB991AFC28C64366954E1D19 /* TrimAnnotationShifterTests.swift */,
+				13FAD0D9852D962D4419DC8F /* TrimStorageTests.swift */,
 				562F2A8FB404F08A50DABD0B /* WeightStackingEvaluatorTests.swift */,
 			);
 			path = StepBackTests;
@@ -412,6 +415,7 @@
 				4181110140BD581DBFB0A380 /* StepTimingTests.swift in Sources */,
 				C97E59DA25A51E16ECA03607 /* ThemeTests.swift in Sources */,
 				AB9467B4E5F44BFF1AA916B1 /* TrimAnnotationShifterTests.swift in Sources */,
+				49AACC760BDA11B944F52A54 /* TrimStorageTests.swift in Sources */,
 				9955BF32B7DB538849A77F77 /* WeightStackingEvaluatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/StepBack/Models/Schema.swift
+++ b/StepBack/Models/Schema.swift
@@ -11,10 +11,10 @@ import SwiftData
 /// sync, on-disk thumbnails, new `ClipSegment` fields, etc.), it ships as a
 /// V2 with an explicit `MigrationStage` between V1 and V2.
 ///
-/// To add V2: copy this enum to `SchemaV2`, declare V2's `models`, then
-/// append a stage in `StepBackMigrationPlan.stages` describing the V1→V2
-/// transition (lightweight if additive-only, custom for renames or data
-/// transformations).
+/// Authoring V2 correctly requires *frozen copies* of every model as it
+/// existed at V1 (nested in this enum), not a second schema pointing at the
+/// same live classes — SwiftData rejects two versioned schemas that share
+/// model types with a "checksum while model is still editable" error.
 enum SchemaV1: VersionedSchema {
     static let versionIdentifier: Schema.Version = .init(1, 0, 0)
 

--- a/StepBack/Services/TrimExportService.swift
+++ b/StepBack/Services/TrimExportService.swift
@@ -43,24 +43,56 @@ enum TrimStorage {
         let url = fileURL(name: name)
         try? FileManager.default.removeItem(at: url)
     }
+
+    // MARK: - Embedded source range
+
+    // Trim files carry the [start, end] window (in the *original* asset's
+    // timeline) they were exported from, encoded in the filename, so a
+    // re-trim can re-export from the original instead of trimming the trim.
+    // Format: `trim-<uuid>__<startMs>__<endMs>.mov`. Legacy trims named
+    // `<uuid>.mov` simply return nil bounds (→ narrow-only fallback).
+
+    static func makeFileName(start: Double, end: Double) -> String {
+        let startMs = Int((max(0, start) * 1000).rounded())
+        let endMs = Int((max(0, end) * 1000).rounded())
+        return "trim-\(UUID().uuidString)__\(startMs)__\(endMs).mov"
+    }
+
+    static func bounds(fromName name: String) -> (start: Double, end: Double)? {
+        let base = (name as NSString).deletingPathExtension
+        let parts = base.components(separatedBy: "__")
+        guard parts.count == 3,
+              let startMs = Int(parts[1]),
+              let endMs = Int(parts[2]),
+              endMs > startMs else { return nil }
+        return (Double(startMs) / 1000, Double(endMs) / 1000)
+    }
 }
 
 /// Exports a sub-range of an `AVAsset` to the sandbox using the passthrough
 /// preset (no re-encode → fast, no quality loss). The caller owns the
 /// returned filename; `TrimStorage.directory` resolves it back to a URL.
+/// The filename embeds `[start, end]` (see `TrimStorage.makeFileName`), so
+/// `start`/`end` here must be in the *original* asset's timeline.
 struct TrimExportService {
 
     func export(
         asset: AVAsset,
         start: Double,
-        end: Double
+        end: Double,
+        recordsOriginalBounds: Bool = true
     ) async throws -> (fileName: String, durationSeconds: Double) {
         let trimmed = max(0, end - start)
         guard trimmed > 0.05 else { throw TrimError.invalidRange }
 
         try TrimStorage.ensureDirectoryExists()
 
-        let fileName = "\(UUID().uuidString).mov"
+        // Only embed the range when start/end are in the *original* timeline.
+        // When trimming an already-trimmed fallback source they aren't, so we
+        // write a legacy-style name (no bounds) → next edit treats it legacy.
+        let fileName = recordsOriginalBounds
+            ? TrimStorage.makeFileName(start: start, end: end)
+            : "\(UUID().uuidString).mov"
         let outputURL = TrimStorage.fileURL(name: fileName)
         // Stale temp from a prior crashed export.
         try? FileManager.default.removeItem(at: outputURL)

--- a/StepBack/Views/PracticeView.swift
+++ b/StepBack/Views/PracticeView.swift
@@ -175,7 +175,9 @@ struct PracticeView: View {
             // of the trim sheet without exporting.
             Task { await vm.reloadAsset(localFileURL: clip.preferredLocalFileURL) }
         }) {
-            TrimView(clip: clip, player: vm.player, initialDuration: vm.duration)
+            // TrimView loads the original in its own player, so it no longer
+            // shares ours.
+            TrimView(clip: clip)
         }
         .sheet(item: $editingSegment) { segment in
             SegmentEditSheet(
@@ -499,11 +501,15 @@ struct PracticeView: View {
                 systemImage: "crop",
                 tint: .surface
             ) {
-                // Park the parent VM in a neutral state — loop bounds and
-                // segment selection would fight TrimView's own seeking
-                // since they share an AVPlayer.
+                // Free our decoder while TrimView is open — it loads the
+                // original in its own player, and two decoders of a long clip
+                // can blow the per-process memory budget. Also stop pose so it
+                // isn't polling a player whose item we just removed. The
+                // onDismiss reload restores playback.
                 vm.pause()
                 vm.clearLoop()
+                poseCoordinator.stop()
+                vm.player.replaceCurrentItem(with: nil)
                 trimSheetPresented = true
             }
             ActionPill(

--- a/StepBack/Views/TrimView.swift
+++ b/StepBack/Views/TrimView.swift
@@ -4,37 +4,48 @@ import SwiftData
 import SwiftUI
 import UIKit
 
-/// Modal trim editor. Shares the parent practice screen's `AVPlayer` so we
-/// don't double the in-memory video buffers — long clips on a phone will
-/// blow past the per-process limit fast if two players are decoding the
-/// same source.
+/// Modal trim editor. Loads the clip's *original* asset (not the parent's
+/// trimmed player), so a trim can be widened as well as narrowed and never
+/// degrades quality by trimming an already-trimmed file. The parent frees
+/// its decoder while this is open so we don't double the in-memory buffers.
 ///
-/// Picks a [start, end] window with two handles, then exports the range
-/// to the sandbox and rebases all annotations on the new timeline.
+/// Picks a [start, end] window with two handles, exports that range from the
+/// original, and rebases all annotations onto the new timeline. The kept
+/// window is recorded in the trim filename so the next edit can re-source
+/// from the original.
 struct TrimView: View {
 
     let clip: DanceClip
-    let player: AVPlayer
-    let initialDuration: Double
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
 
-    @State private var duration: Double
+    private let photosService: PhotosServicing
+
+    @State private var player = AVPlayer()
+    @State private var sourceAsset: AVURLAsset?
+    /// Offset (seconds) from the current annotation timeline to the source
+    /// asset's timeline. >0 when re-trimming a clip whose existing trim began
+    /// `sourceOffset` into the original; 0 for a first trim or the fallback.
+    @State private var sourceOffset: Double = 0
+    /// True when trimming the full original (handles can widen); false when
+    /// we fell back to the already-trimmed file (narrow only).
+    @State private var sourceIsOriginal = false
+
+    @State private var duration: Double = 0
     @State private var currentTime: Double = 0
     @State private var isPlaying: Bool = false
     @State private var trimStart: Double = 0
-    @State private var trimEnd: Double
+    @State private var trimEnd: Double = 0
+    @State private var isReady = false
+    @State private var loadError: String?
     @State private var isExporting = false
     @State private var exportError: String?
     @State private var timeObserver: Any?
 
-    init(clip: DanceClip, player: AVPlayer, initialDuration: Double) {
+    init(clip: DanceClip, photosService: PhotosServicing = PhotosService()) {
         self.clip = clip
-        self.player = player
-        self.initialDuration = initialDuration
-        _duration = State(initialValue: initialDuration)
-        _trimEnd = State(initialValue: initialDuration)
+        self.photosService = photosService
     }
 
     var body: some View {
@@ -58,10 +69,7 @@ struct TrimView: View {
                 }
             }
         }
-        .onAppear {
-            seek(to: 0)
-            attachTimeObserver()
-        }
+        .task { await loadSource() }
         .onDisappear { detachTimeObserver() }
         .keepScreenAwake()
         .preferredColorScheme(.dark)
@@ -69,29 +77,48 @@ struct TrimView: View {
 
     // MARK: - Content
 
+    @ViewBuilder
     private var content: some View {
-        VStack(spacing: 16) {
-            videoPanel
-            handles
-            preset
-            if let exportError {
-                Text(exportError)
+        if let loadError {
+            VStack(spacing: 12) {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.system(size: 36, weight: .light))
+                    .foregroundStyle(Theme.Color.accent)
+                Text("Couldn't open this clip to trim")
+                    .font(Theme.Font.bodyEmphasized)
+                    .foregroundStyle(Theme.Color.textPrimary)
+                Text(loadError)
                     .font(Theme.Font.caption)
-                    .foregroundStyle(.red.opacity(0.9))
+                    .foregroundStyle(Theme.Color.textSecondary)
                     .multilineTextAlignment(.center)
-                    .padding(.horizontal, 16)
+                    .padding(.horizontal, 24)
             }
-            if isExporting {
-                HStack(spacing: 8) {
-                    ProgressView().tint(Theme.Color.accent)
-                    Text("Exporting…")
+        } else if !isReady {
+            ProgressView().tint(Theme.Color.accent)
+        } else {
+            VStack(spacing: 16) {
+                videoPanel
+                handles
+                preset
+                if let exportError {
+                    Text(exportError)
                         .font(Theme.Font.caption)
-                        .foregroundStyle(Theme.Color.textSecondary)
+                        .foregroundStyle(.red.opacity(0.9))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 16)
                 }
+                if isExporting {
+                    HStack(spacing: 8) {
+                        ProgressView().tint(Theme.Color.accent)
+                        Text("Exporting…")
+                            .font(Theme.Font.caption)
+                            .foregroundStyle(Theme.Color.textSecondary)
+                    }
+                }
+                Spacer(minLength: 0)
             }
-            Spacer(minLength: 0)
+            .padding(.top, 8)
         }
-        .padding(.top, 8)
     }
 
     private var videoPanel: some View {
@@ -165,10 +192,12 @@ struct TrimView: View {
 
     private var preset: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text("Heads up")
+            Text(sourceIsOriginal ? "Re-editable trim" : "Heads up")
                 .font(.system(.footnote, design: .rounded, weight: .semibold))
                 .foregroundStyle(Theme.Color.textSecondary)
-            Text("Trimming replaces the clip's source with a new file. Patterns and beat times are kept and shifted to the new timeline; anything outside the kept window is dropped.")
+            Text(sourceIsOriginal
+                ? "Trim is re-exported from your original video, so you can widen or narrow it later. Patterns and beat times are shifted to the new window; any that fall outside it are dropped."
+                : "Trimming replaces the clip's source with a new file. Patterns and beat times are shifted to the new window; anything outside it is dropped.")
                 .font(Theme.Font.caption)
                 .foregroundStyle(Theme.Color.textTertiary)
         }
@@ -235,16 +264,83 @@ struct TrimView: View {
         player.pause()
     }
 
+    // MARK: - Loading the source
+
+    private func loadSource() async {
+        do {
+            let resolved = try await resolveTrimSource()
+            let loaded = (try? await resolved.asset.load(.duration).seconds) ?? 0
+            guard loaded.isFinite, loaded > 0 else {
+                loadError = "Couldn't read the clip's length."
+                return
+            }
+            sourceAsset = resolved.asset
+            sourceOffset = resolved.offset
+            sourceIsOriginal = resolved.isOriginal
+            duration = loaded
+
+            // Open showing the current trim window when we can map it onto the
+            // source (re-editing from the original); otherwise the whole source.
+            if resolved.isOriginal,
+               let name = clip.trimmedFileName,
+               let bounds = TrimStorage.bounds(fromName: name) {
+                trimStart = max(0, min(bounds.start, loaded))
+                trimEnd = max(trimStart + 0.05, min(bounds.end, loaded))
+            } else {
+                trimStart = 0
+                trimEnd = loaded
+            }
+
+            let item = AVPlayerItem(asset: resolved.asset)
+            item.audioTimePitchAlgorithm = .timeDomain
+            player.replaceCurrentItem(with: item)
+            isReady = true
+            seek(to: trimStart)
+            attachTimeObserver()
+        } catch {
+            loadError = error.localizedDescription
+        }
+    }
+
+    /// Decides what to trim from and how the current annotation timeline maps
+    /// onto it. Prefers the full original (so the trim can widen) whenever the
+    /// offset is known — i.e. the clip was never trimmed, or its trim filename
+    /// records its source range. Falls back to the already-trimmed file
+    /// (narrow only) for legacy trims or when the original is gone.
+    private func resolveTrimSource() async throws
+        -> (asset: AVURLAsset, offset: Double, isOriginal: Bool) {
+        let parsedStart = clip.trimmedFileName
+            .flatMap { TrimStorage.bounds(fromName: $0)?.start }
+        let offsetKnown = clip.trimmedFileName == nil || parsedStart != nil
+
+        if offsetKnown {
+            if let url = clip.originalFileURL {
+                return (AVURLAsset(url: url), parsedStart ?? 0, true)
+            }
+            if let urlAsset = try? await photosService.resolveAVAsset(for: clip.assetIdentifier) {
+                return (urlAsset, parsedStart ?? 0, true)
+            }
+        }
+
+        // Fallback: trim the current playable file. Annotations already align
+        // with it (offset 0), but we can only narrow.
+        if let url = clip.preferredLocalFileURL {
+            return (AVURLAsset(url: url), 0, false)
+        }
+        if let urlAsset = try? await photosService.resolveAVAsset(for: clip.assetIdentifier) {
+            return (urlAsset, 0, false)
+        }
+        throw TrimError.exportFailed("Couldn't load the clip to trim.")
+    }
+
     // MARK: - Apply
 
     private var canApply: Bool {
-        duration > 0
-            && trimEnd - trimStart > 0.05
-            && (trimStart > 0.05 || trimEnd < duration - 0.05)
+        isReady && duration > 0 && trimEnd - trimStart > 0.05
     }
 
     private func applyTrim() async {
-        guard let asset = player.currentItem?.asset else {
+        guard let asset = sourceAsset else {
             exportError = "Clip isn't ready yet."
             return
         }
@@ -256,7 +352,8 @@ struct TrimView: View {
             let result = try await TrimExportService().export(
                 asset: asset,
                 start: trimStart,
-                end: trimEnd
+                end: trimEnd,
+                recordsOriginalBounds: sourceIsOriginal
             )
             applyToModel(fileName: result.fileName, newDuration: result.durationSeconds)
             isExporting = false
@@ -274,21 +371,26 @@ struct TrimView: View {
         clip.trimmedFileName = fileName
         clip.durationSeconds = newDuration
 
-        let start = trimStart
-        let end = trimEnd
+        // Annotations live in the *current* timeline. Express the new window
+        // there too (subtract the source offset) so widening — where
+        // newStart < sourceOffset, making rebaseStart negative — shifts them
+        // forward correctly instead of dropping them.
+        let rebaseStart = trimStart - sourceOffset
+        let rebaseEnd = trimEnd - sourceOffset
+
         clip.firstDownbeatSeconds = clip.firstDownbeatSeconds.flatMap {
-            TrimAnnotationShifter.shiftPoint($0, trimStart: start, trimEnd: end)
+            TrimAnnotationShifter.shiftPoint($0, trimStart: rebaseStart, trimEnd: rebaseEnd)
         }
         clip.setBeatTimes(
-            TrimAnnotationShifter.shiftBeatTimes(clip.beatTimes, trimStart: start, trimEnd: end)
+            TrimAnnotationShifter.shiftBeatTimes(clip.beatTimes, trimStart: rebaseStart, trimEnd: rebaseEnd)
         )
 
         for segment in clip.segments {
             if let shifted = TrimAnnotationShifter.shiftRange(
                 start: segment.startSeconds,
                 end: segment.endSeconds,
-                trimStart: start,
-                trimEnd: end
+                trimStart: rebaseStart,
+                trimEnd: rebaseEnd
             ) {
                 segment.startSeconds = shifted.start
                 segment.endSeconds = shifted.end

--- a/StepBackTests/TrimAnnotationShifterTests.swift
+++ b/StepBackTests/TrimAnnotationShifterTests.swift
@@ -22,6 +22,28 @@ final class TrimAnnotationShifterTests: XCTestCase {
         XCTAssertEqual(TrimAnnotationShifter.shiftPoint(12, trimStart: 5, trimEnd: 12), 7)
     }
 
+    // MARK: - Widening (negative trimStart)
+
+    // When a re-trim *widens* the window, the trim range expressed in the
+    // current timeline has a negative start. Annotations should shift forward
+    // (we added time before them), not drop. This is the property the
+    // re-editable trim depends on.
+
+    func testShiftPointWithNegativeTrimStartShiftsForward() {
+        // Widened by 3s in front: a point at current-time 4 moves to 7.
+        XCTAssertEqual(
+            TrimAnnotationShifter.shiftPoint(4, trimStart: -3, trimEnd: 17),
+            7
+        )
+    }
+
+    func testShiftRangeWithNegativeTrimStartShiftsForward() {
+        let result = TrimAnnotationShifter.shiftRange(
+            start: 2, end: 10, trimStart: -3, trimEnd: 17
+        )
+        XCTAssertEqual(result, .init(start: 5, end: 13))
+    }
+
     // MARK: - Ranges
 
     func testShiftRangeFullyInsideRebasesWithoutClamping() {

--- a/StepBackTests/TrimStorageTests.swift
+++ b/StepBackTests/TrimStorageTests.swift
@@ -1,0 +1,45 @@
+@testable import StepBack
+import XCTest
+
+final class TrimStorageTests: XCTestCase {
+
+    func testMakeFileNameRoundTripsThroughBounds() {
+        let name = TrimStorage.makeFileName(start: 5.25, end: 12.5)
+        let bounds = TrimStorage.bounds(fromName: name)
+        XCTAssertEqual(bounds?.start ?? -1, 5.25, accuracy: 0.001)
+        XCTAssertEqual(bounds?.end ?? -1, 12.5, accuracy: 0.001)
+    }
+
+    func testMakeFileNameUsesMillisecondPrecision() {
+        let name = TrimStorage.makeFileName(start: 3.219, end: 5.0)
+        // 3.219s → 3219 ms → 3.219 on the way back (ms-resolution).
+        let bounds = TrimStorage.bounds(fromName: name)
+        XCTAssertEqual(bounds?.start ?? -1, 3.219, accuracy: 0.0005)
+    }
+
+    func testMakeFileNameHasMovExtension() {
+        XCTAssertTrue(TrimStorage.makeFileName(start: 0, end: 1).hasSuffix(".mov"))
+    }
+
+    func testLegacyNameHasNoBounds() {
+        XCTAssertNil(TrimStorage.bounds(fromName: "\(UUID().uuidString).mov"))
+    }
+
+    func testMalformedNameHasNoBounds() {
+        XCTAssertNil(TrimStorage.bounds(fromName: "trim-abc__notanumber__500.mov"))
+        XCTAssertNil(TrimStorage.bounds(fromName: "trim-abc__500.mov"))   // only one number
+        XCTAssertNil(TrimStorage.bounds(fromName: "plain.mov"))
+    }
+
+    func testBoundsRejectsNonIncreasingRange() {
+        // end must be strictly after start.
+        let name = "trim-x__5000__5000.mov"
+        XCTAssertNil(TrimStorage.bounds(fromName: name))
+    }
+
+    func testBoundsParsesAWellFormedName() {
+        let bounds = TrimStorage.bounds(fromName: "trim-DEADBEEF__2000__9000.mov")
+        XCTAssertEqual(bounds?.start ?? -1, 2.0, accuracy: 0.001)
+        XCTAssertEqual(bounds?.end ?? -1, 9.0, accuracy: 0.001)
+    }
+}


### PR DESCRIPTION
The third High-tier review item: trims were destructive (re-trimming trimmed the already-trimmed file → lossy, and you could never widen back out). Now a trim is fully **re-editable**.

## What changed for you

- Open Trim on an already-trimmed clip → it loads your **original** video with the handles already at your current window. Drag them **wider or narrower**. Apply re-exports from the original — no quality loss from chaining trims, and widening actually brings the video back.

## How it's stored (and why no schema migration)

The kept `[start, end]` window (original-timeline) is encoded into the trim filename: `trim-<uuid>__<startMs>__<endMs>.mov`. The next edit parses it to know the offset between the current annotation timeline and the original. Legacy trims (`<uuid>.mov`) parse to nil and fall back to the old narrow-only behaviour.

**I first tried the SwiftData field + SchemaV2 route** (what I'd flagged in the review). It trips SwiftData's *"checksum while model is still editable"* error: a correct `VersionedSchema` V2 needs **frozen copies** of every model as it existed at V1, and the real on-disk migration can't be validated without your actual library — too risky to brick your data on a migration I can't test. Filename-encoding delivers the same feature with **zero migration risk**. I left the lesson in a `Schema.swift` comment for the next attempt.

## Implementation

- `TrimStorage.makeFileName` / `bounds(fromName:)` — build + parse the embedded range.
- `TrimExportService.export(...recordsOriginalBounds:)` — only encodes the range when the export coords are truly original (false for the fallback path).
- `TrimView` loads the original in its own player, opens at the current window, rebases annotations by `(trimStart - sourceOffset)` — **negative when widening**, which shifts annotations forward instead of dropping them. (`TrimAnnotationShifter` already handled negative starts; added tests to lock it in.)
- `PracticeView` frees its decoder + stops pose while Trim is open (TrimView no longer shares the parent player; two decoders of a long clip blow the memory budget), and reloads on dismiss. This also closes the concurrency-review finding that pose kept polling during Trim.

## Tests

179 pass (was 170). 7 `TrimStorage` (round-trip, ms precision, legacy/malformed → nil, non-increasing rejected), 2 shifter widening (negative `trimStart`).

## Known limit

Widening recovers the **video** fully, but annotations a *prior narrow* dropped don't come back (they were deleted from the store). The in-sheet "Re-editable trim" copy says so.

## Validate on device

- Trim a clip to a window, Apply. Re-open Trim → handles show that window over the full original; **widen** it, Apply → video is back, patterns inside the window survive.
- Trim a long clip and confirm no memory pressure (parent decoder is freed while trimming).
